### PR TITLE
Support project deletion

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -617,7 +617,7 @@ PROJECTROLES_ALLOW_LOCAL_USERS = env.bool(
 PROJECTROLES_ALLOW_ANONYMOUS = False
 
 # Enable project modify API
-PROJECTROLES_ENABLE_MODIFY_API = False
+PROJECTROLES_ENABLE_MODIFY_API = True
 # List of apps for executing project modify API actions in the given order. If
 # not set, backend and project apps will execute in alphabetical order by name.
 PROJECTROLES_MODIFY_API_APPS = []

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -249,3 +249,23 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
             pass
 
         return None
+
+    def perform_project_delete(self, project: Project):
+        """
+        Clean-up actions to be performed when a project is deleted
+
+        Ensure that all containers belonging to the project are stopped and
+        deleted.
+
+        NOTE: the method is called only if the setting
+        ``PROJECTROLES_ENABLE_MODIFY_API`` is True.
+
+        :param project: The project being deleted
+        """
+        containers = Container.objects.filter(project=project)
+        # NOTE: the project modify API plugin only passes the project as arg to
+        # this function, not the user. Hence, we use the project owner for the
+        # BackgroundJob user, as a workaround.
+        user = project.get_owner().user
+        for container in containers:
+            self._container_delete_docker(container, user)

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -12,10 +12,12 @@ from projectroles.plugins import (
     ProjectAppPluginPoint,
     PluginObjectLink,
     PluginCategoryStatistic,
+    ProjectModifyPluginMixin,
 )
 
 from containers.models import Container
 from containers.urls import urlpatterns
+from containers.views import ContainerModifyMixin
 
 from containertemplates.models import (
     ContainerTemplateSite,
@@ -31,7 +33,9 @@ PROJECT_TYPE_PROJECT = SODAR_CONSTANTS['PROJECT_TYPE_PROJECT']
 # Samplesheets project app plugin ----------------------------------------------
 
 
-class ProjectAppPlugin(ProjectAppPluginPoint):
+class ProjectAppPlugin(
+    ProjectAppPluginPoint, ProjectModifyPluginMixin, ContainerModifyMixin
+):
     """Plugin for registering app with Projectroles"""
 
     # Properties required by django-plugins ------------------------------

--- a/containers/tests/helpers.py
+++ b/containers/tests/helpers.py
@@ -28,7 +28,16 @@ from containertemplates.tests.factories import (
     ContainerTemplateSiteFactory,
     ContainerTemplateProjectFactory,
 )
+from projectroles.models import (
+    Role,
+    RoleAssignment,
+    SODAR_CONSTANTS,
+    ROLE_RANKING,
+)
 from projectroles.tests.base import APIViewTestBase
+
+
+PROJECT_ROLE_OWNER = SODAR_CONSTANTS["PROJECT_ROLE_OWNER"]
 
 
 class TestContainerCreationMixin:
@@ -75,6 +84,16 @@ class TestBase(TestContainerCreationMixin, TestCase):
         self.superuser.is_staff = True
         self.superuser.is_superuser = True
         self.superuser.save()
+
+        self.user = self.make_user("alice")
+        self.user.save()
+
+        self.role_owner = Role.objects.get_or_create(
+            name=PROJECT_ROLE_OWNER, rank=ROLE_RANKING[PROJECT_ROLE_OWNER]
+        )[0]
+        self.role_owner_as = RoleAssignment.objects.create(
+            project=self.project, user=self.user, role=self.role_owner
+        )
 
 
 class ContainersAPIViewTestBase(APIViewTestBase):

--- a/containers/tests/helpers.py
+++ b/containers/tests/helpers.py
@@ -37,7 +37,7 @@ from projectroles.models import (
 from projectroles.tests.base import APIViewTestBase
 
 
-PROJECT_ROLE_OWNER = SODAR_CONSTANTS["PROJECT_ROLE_OWNER"]
+PROJECT_ROLE_OWNER = SODAR_CONSTANTS['PROJECT_ROLE_OWNER']
 
 
 class TestContainerCreationMixin:
@@ -85,7 +85,7 @@ class TestBase(TestContainerCreationMixin, TestCase):
         self.superuser.is_superuser = True
         self.superuser.save()
 
-        self.user = self.make_user("alice")
+        self.user = self.make_user('alice')
         self.user.save()
 
         self.role_owner = Role.objects.get_or_create(

--- a/containers/tests/test_plugins.py
+++ b/containers/tests/test_plugins.py
@@ -1,0 +1,69 @@
+"""Tests for the plugin methods."""
+
+from unittest.mock import patch
+
+from django.test import override_settings
+from django.urls import reverse
+
+from containers.models import Container, ContainerBackgroundJob
+from containers.tests.helpers import TestBase
+
+
+class TestProjectrolesModifyAPI(TestBase):
+    """Tests for the methods in ``ProjectModifyPluginMixin``."""
+
+    def setUp(self):
+        super().setUp()
+        self.create_two_containers()
+
+    @patch("containers.statemachines.ActionSwitch._delete")
+    @override_settings(PROJECTROLES_ENABLE_MODIFY_API=True)
+    def test_project_delete(self, mock):
+        """Test that containers belonging to a project are deleted with it"""
+        self.assertEqual(
+            Container.objects.filter(project=self.project).count(), 2
+        )
+        with self.login(self.user):
+            response = self.client.post(
+                reverse(
+                    "projectroles:delete",
+                    kwargs={"project": self.project.sodar_uuid},
+                ),
+                {"delete_host_confirm": "testserver"},
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertRedirects(response, reverse("home"))
+        self.assertEqual(
+            Container.objects.filter(project=self.project).count(), 0
+        )
+        self.assertEqual(
+            ContainerBackgroundJob.objects.filter(project=self.project).count(),
+            0,
+        )
+        mock.assert_called()
+
+    @patch("containers.statemachines.ActionSwitch._delete")
+    @override_settings(PROJECTROLES_ENABLE_MODIFY_API=False)
+    def test_project_delete_disabled(self, mock):
+        """Test that containers belonging to a project are NOT deleted"""
+        self.assertEqual(
+            Container.objects.filter(project=self.project).count(), 2
+        )
+        with self.login(self.superuser):
+            response = self.client.post(
+                reverse(
+                    "projectroles:delete",
+                    kwargs={"project": self.project.sodar_uuid},
+                ),
+                {"delete_host_confirm": "testserver"},
+            )
+            self.assertEqual(response.status_code, 302)
+            self.assertRedirects(response, reverse("home"))
+        self.assertEqual(
+            Container.objects.filter(project=self.project).count(), 0
+        )
+        self.assertEqual(
+            ContainerBackgroundJob.objects.filter(project=self.project).count(),
+            0,
+        )
+        mock.assert_not_called()

--- a/containers/tests/test_plugins.py
+++ b/containers/tests/test_plugins.py
@@ -16,7 +16,7 @@ class TestProjectrolesModifyAPI(TestBase):
         super().setUp()
         self.create_two_containers()
 
-    @patch("containers.statemachines.ActionSwitch._delete")
+    @patch('containers.statemachines.ActionSwitch._delete')
     @override_settings(PROJECTROLES_ENABLE_MODIFY_API=True)
     def test_project_delete(self, mock):
         """Test that containers belonging to a project are deleted with it"""
@@ -26,13 +26,13 @@ class TestProjectrolesModifyAPI(TestBase):
         with self.login(self.user):
             response = self.client.post(
                 reverse(
-                    "projectroles:delete",
-                    kwargs={"project": self.project.sodar_uuid},
+                    'projectroles:delete',
+                    kwargs={'project': self.project.sodar_uuid},
                 ),
-                {"delete_host_confirm": "testserver"},
+                {'delete_host_confirm': 'testserver'},
             )
             self.assertEqual(response.status_code, 302)
-            self.assertRedirects(response, reverse("home"))
+            self.assertRedirects(response, reverse('home'))
         self.assertEqual(
             Container.objects.filter(project=self.project).count(), 0
         )
@@ -42,7 +42,7 @@ class TestProjectrolesModifyAPI(TestBase):
         )
         mock.assert_called()
 
-    @patch("containers.statemachines.ActionSwitch._delete")
+    @patch('containers.statemachines.ActionSwitch._delete')
     @override_settings(PROJECTROLES_ENABLE_MODIFY_API=False)
     def test_project_delete_disabled(self, mock):
         """Test that containers belonging to a project are NOT deleted"""
@@ -52,13 +52,13 @@ class TestProjectrolesModifyAPI(TestBase):
         with self.login(self.superuser):
             response = self.client.post(
                 reverse(
-                    "projectroles:delete",
-                    kwargs={"project": self.project.sodar_uuid},
+                    'projectroles:delete',
+                    kwargs={'project': self.project.sodar_uuid},
                 ),
-                {"delete_host_confirm": "testserver"},
+                {'delete_host_confirm': 'testserver'},
             )
             self.assertEqual(response.status_code, 302)
-            self.assertRedirects(response, reverse("home"))
+            self.assertRedirects(response, reverse('home'))
         self.assertEqual(
             Container.objects.filter(project=self.project).count(), 0
         )

--- a/containers/views.py
+++ b/containers/views.py
@@ -2,6 +2,8 @@ import inspect
 import logging
 from ipaddress import ip_address
 from typing import AsyncGenerator, Optional
+from urllib3.exceptions import NewConnectionError
+from urllib3.response import is_fp_closed
 from wsgiref.util import FileWrapper
 
 from django.http import (
@@ -14,6 +16,7 @@ from django.http import (
 )
 from django.conf import settings
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.db import transaction
 from django.shortcuts import redirect
@@ -27,6 +30,13 @@ from django.views.generic import (
     ListView,
 )
 from django.views.generic.detail import SingleObjectMixin
+from revproxy.response import get_streaming_amt
+from revproxy.utils import (
+    set_response_headers,
+    should_stream,
+    cookie_from_string,
+)
+from revproxy.views import ProxyView
 
 from config.settings.base import KIOSC_CONTAINER_DEFAULT_LOG_LINES
 from bgjobs.models import BackgroundJob, LOG_LEVEL_DEBUG
@@ -39,15 +49,6 @@ from projectroles.views import (
     ProjectContextMixin,
     ProjectPermissionMixin,
 )
-from revproxy.response import get_streaming_amt
-from revproxy.utils import (
-    set_response_headers,
-    should_stream,
-    cookie_from_string,
-)
-from revproxy.views import ProxyView
-from urllib3.exceptions import NewConnectionError
-from urllib3.response import is_fp_closed
 
 from containers.forms import ContainerForm, FileSelectorForm
 from containers.models import (
@@ -74,6 +75,7 @@ from containertemplates.forms import ContainerTemplateSelectorForm
 
 logger = logging.getLogger(__name__)
 plugin_api = PluginAPI()
+User = get_user_model()
 
 APP_NAME = 'containers'
 CELERY_SUBMIT_COUNTDOWN = 0.5
@@ -110,6 +112,77 @@ async def _stream_response(
 
             if data:
                 yield data
+
+
+class ContainerModifyMixin:
+    @classmethod
+    @transaction.atomic
+    def _container_delete_docker(cls, container: Container, user: User) -> bool:
+        """Delete a container
+
+        This method deletes the container from Docker as a background job. It
+        also creates log entries and timeline events.
+
+        NOTE: the container is NOT deleted from the database with this method,
+        just from the Docker daemon.
+
+        :param container: Container object to be deleted
+        :param user: User on behalf of whom the action is performed
+        :return: True if the action succeeded, False otherwise
+        """
+        project = container.project
+        timeline = plugin_api.get_backend_api("timeline_backend")
+        bg_job = BackgroundJob.objects.create(
+            name="Delete container",
+            project=project,
+            job_type=ContainerBackgroundJob.spec_name,
+            user=user,
+        )
+        job = ContainerBackgroundJob.objects.create(
+            action=ACTION_DELETE,
+            project=project,
+            container=container,
+            bg_job=bg_job,
+        )
+
+        # Add container log entry
+        container.log_entries.create(
+            text="Delete",
+            process=PROCESS_ACTION,
+            user=user,
+        )
+
+        # No async task
+        container_task(job_id=job.id)
+        container.refresh_from_db()
+
+        if container.state not in (STATE_INITIAL, STATE_DELETED):
+            # Add timeline event
+            if timeline:
+                timeline.add_event(
+                    project=project,
+                    app_name=APP_NAME,
+                    user=user,
+                    event_name="delete_container",
+                    description=f"deleting of {container.get_display_name()} failed",
+                    status_type=timeline.TL_STATUS_FAILED,
+                )
+            logger.error(
+                f"Failed deleting container {container.get_display_name()}",
+            )
+            return False
+
+        # Add timeline event
+        if timeline:
+            timeline.add_event(
+                project=project,
+                app_name=APP_NAME,
+                user=user,
+                event_name="delete_container",
+                description=f"deleted {container.get_display_name()}",
+                status_type=timeline.TL_STATUS_OK,
+            )
+        return True
 
 
 class ContainerCreateView(
@@ -177,6 +250,7 @@ class ContainerDeleteView(
     LoggedInPermissionMixin,
     ProjectPermissionMixin,
     ProjectContextMixin,
+    ContainerModifyMixin,
     DeleteView,
 ):
     """View for deleting a container."""
@@ -197,48 +271,12 @@ class ContainerDeleteView(
             kwargs={'project': self.object.project.sodar_uuid},
         )
 
-    @transaction.atomic
     def delete(self, request, *args, **kwargs):
-        timeline = plugin_api.get_backend_api('timeline_backend')
         container = self.get_object()
         project = self.get_project()
+        success = self._container_delete_docker(container, request.user)
 
-        bg_job = BackgroundJob.objects.create(
-            name='Delete container',
-            project=project,
-            job_type=ContainerBackgroundJob.spec_name,
-            user=request.user,
-        )
-        job = ContainerBackgroundJob.objects.create(
-            action=ACTION_DELETE,
-            project=project,
-            container=container,
-            bg_job=bg_job,
-        )
-
-        # Add container log entry
-        container.log_entries.create(
-            text='Delete',
-            process=PROCESS_ACTION,
-            user=request.user,
-        )
-
-        # No async task
-        container_task(job_id=job.id)
-        container.refresh_from_db()
-
-        if container.state not in (STATE_INITIAL, STATE_DELETED):
-            # Add timeline event
-            if timeline:
-                timeline.add_event(
-                    project=project,
-                    app_name=APP_NAME,
-                    user=request.user,
-                    event_name='delete_container',
-                    description=f'deleting of {container.get_display_name()} failed',
-                    status_type=timeline.TL_STATUS_FAILED,
-                )
-
+        if not success:
             messages.error(
                 request,
                 f'Failed deleting container {container.get_display_name()}',
@@ -249,17 +287,6 @@ class ContainerDeleteView(
                     'containers:list',
                     kwargs={'project': project.sodar_uuid},
                 )
-            )
-
-        # Add timeline event
-        if timeline:
-            timeline.add_event(
-                project=project,
-                app_name=APP_NAME,
-                user=request.user,
-                event_name='delete_container',
-                description=f'deleted {container.get_display_name()}',
-                status_type=timeline.TL_STATUS_OK,
             )
 
         return super().delete(request, *args, **kwargs)

--- a/containers/views.py
+++ b/containers/views.py
@@ -131,9 +131,9 @@ class ContainerModifyMixin:
         :return: True if the action succeeded, False otherwise
         """
         project = container.project
-        timeline = plugin_api.get_backend_api("timeline_backend")
+        timeline = plugin_api.get_backend_api('timeline_backend')
         bg_job = BackgroundJob.objects.create(
-            name="Delete container",
+            name='Delete container',
             project=project,
             job_type=ContainerBackgroundJob.spec_name,
             user=user,
@@ -147,7 +147,7 @@ class ContainerModifyMixin:
 
         # Add container log entry
         container.log_entries.create(
-            text="Delete",
+            text='Delete',
             process=PROCESS_ACTION,
             user=user,
         )
@@ -163,12 +163,12 @@ class ContainerModifyMixin:
                     project=project,
                     app_name=APP_NAME,
                     user=user,
-                    event_name="delete_container",
-                    description=f"deleting of {container.get_display_name()} failed",
+                    event_name='delete_container',
+                    description=f'deleting of {container.get_display_name()} failed',
                     status_type=timeline.TL_STATUS_FAILED,
                 )
             logger.error(
-                f"Failed deleting container {container.get_display_name()}",
+                f'Failed deleting container {container.get_display_name()}',
             )
             return False
 
@@ -178,8 +178,8 @@ class ContainerModifyMixin:
                 project=project,
                 app_name=APP_NAME,
                 user=user,
-                event_name="delete_container",
-                description=f"deleted {container.get_display_name()}",
+                event_name='delete_container',
+                description=f'deleted {container.get_display_name()}',
                 status_type=timeline.TL_STATUS_OK,
             )
         return True


### PR DESCRIPTION
In this PR `perform_project_delete()` is added to the `containers` plugin (see #178). This function is defined in `ProjectModifyPluginMixin`, and it is called by plugins whenever a project is deleted. As such, its role is to perform plugin-specific clean up actions. In this case, it simply stops and deletes containers belonging to that project.

I ended up adding a `containers.views.ContainerModifyMixin` which provides a function for removing containers. It is used both in `ContainerDeleteView` and in `perform_project_delete()`.