### PR TITLE
Support read only mode

### DIFF
--- a/containers/rules.py
+++ b/containers/rules.py
@@ -16,57 +16,78 @@ rules.add_perm(
 # Allow creating containers
 rules.add_perm(
     "containers.create_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow updating containers
 rules.add_perm(
     "containers.edit_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow deleting containers
 rules.add_perm(
     "containers.delete_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow starting containers
 rules.add_perm(
     "containers.start_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow stopping containers
 rules.add_perm(
     "containers.stop_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow pausing containers
 rules.add_perm(
     "containers.pause_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow unpausing containers
 rules.add_perm(
     "containers.unpause_container",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow using the proxy

--- a/containers/tests/test_permissions.py
+++ b/containers/tests/test_permissions.py
@@ -347,3 +347,254 @@ class TestContainerPermissions(ProjectPermissionTestBase):
             ),
         )
         self.assert_response(url, bad_users, 302)
+
+
+class TestContainerPermissionReadOnly(ProjectPermissionTestBase):
+    """Test permissions for container app when site is in read-only mode"""
+
+    def setUp(self):
+        super().setUp()
+        self.container = ContainerFactory(project=self.project)
+        self.set_site_read_only()
+        self.good_users = [self.superuser]
+        self.bad_users = [
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+            self.user_no_roles,
+            self.anonymous,
+            self.user_finder_cat,
+        ]
+
+    def test_container_list(self):
+        """Test permissions for the ``list`` view in read-only mode."""
+        url = reverse(
+            "containers:list",
+            kwargs={"project": self.project.sodar_uuid},
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(url, good_users, 200)
+        self.assert_response(url, bad_users, 302)
+
+    def test_container_create(self):
+        """Test permissions for the ``create`` view in read-only mode."""
+        url = reverse(
+            "containers:create",
+            kwargs={"project": self.project.sodar_uuid},
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_container_update(self):
+        """Test permissions for the ``update`` view in read-only mode."""
+        url = reverse(
+            "containers:update",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_container_detail(self):
+        """Test permissions for the ``detail`` view in read-only mode."""
+        url = reverse(
+            "containers:detail",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(url, good_users, 200)
+        self.assert_response(url, bad_users, 302)
+
+    def test_container_delete(self):
+        """Test permissions for the ``delete`` view in read-only mode."""
+        url = reverse(
+            "containers:delete",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    @patch("containers.tasks.container_task.apply_async")
+    def test_container_start(self, mock):
+        """Test permissions for the ``start`` view in read-only mode."""
+        url = reverse(
+            "containers:start",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containers:detail",
+                kwargs={"container": self.container.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+        mock.assert_called()
+
+    @patch("containers.tasks.container_task.apply_async")
+    def test_container_stop(self, mock):
+        """Test permissions for the ``stop`` view in read-only mode."""
+        url = reverse(
+            "containers:stop",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containers:detail",
+                kwargs={"container": self.container.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+        mock.assert_called()
+
+    @patch("containers.tasks.container_task.apply_async")
+    def test_container_restart(self, mock):
+        """Test permissions for the ``restart`` view in read-only mode."""
+        url = reverse(
+            "containers:restart",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containers:detail",
+                kwargs={"container": self.container.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+        mock.assert_called()
+
+    @patch("containers.tasks.container_task.apply_async")
+    def test_container_pause(self, mock):
+        """Test permissions for the ``pause`` view in read-only mode."""
+        url = reverse(
+            "containers:pause",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containers:detail",
+                kwargs={"container": self.container.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+        mock.assert_called()
+
+    @patch("containers.tasks.container_task.apply_async")
+    def test_container_unpause(self, mock):
+        """Test permissions for the ``unpause`` view in read-only mode."""
+        url = reverse(
+            "containers:unpause",
+            kwargs={"container": self.container.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containers:detail",
+                kwargs={"container": self.container.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+        mock.assert_called()
+
+    # urllib3-mock not working with Python 3.11+ :-/
+    @responses.activate
+    def test_proxy(self):
+        """Test permissions for the ``proxy`` view in read-only mode."""
+
+        self.container.state = STATE_RUNNING
+        self.container.save()
+
+        def request_callback(request):
+            return 200, {}, "abc".encode("utf-8")
+
+        responses.add_callback(
+            "GET",
+            f"/{self.container.container_path}",
+            callback=request_callback,
+        )
+        url = reverse(
+            "containers:proxy",
+            kwargs={
+                "container": self.container.sodar_uuid,
+                "path": self.container.container_path,
+            },
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(url, good_users, 200)
+        self.assert_response(url, bad_users, 302)
+
+    def test_proxy_lobby(self):
+        """Test permissions for the ``proxy-lobby`` view in read-only mode."""
+
+        self.container.state = STATE_RUNNING
+        self.container.save()
+
+        def request_callback(request):
+            return 200, {}, "abc".encode("utf-8")
+
+        responses.add_callback(
+            "GET",
+            f"/{self.container.container_path}",
+            callback=request_callback,
+        )
+        url = reverse(
+            "containers:proxy-lobby",
+            kwargs={
+                "container": self.container.sodar_uuid,
+            },
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(
+            url,
+            good_users,
+            302,
+            redirect_user=reverse(
+                "containers:proxy",
+                kwargs={
+                    "container": self.container.sodar_uuid,
+                    "path": self.container.container_path,
+                },
+            ),
+        )
+        self.assert_response(url, bad_users, 302)

--- a/containertemplates/rules.py
+++ b/containertemplates/rules.py
@@ -45,31 +45,43 @@ rules.add_perm(
 # Allow creating project-wide templates.
 rules.add_perm(
     "containertemplates.project_create",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow updating project-wide templates.
 rules.add_perm(
     "containertemplates.project_edit",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow deleting project-wide templates.
 rules.add_perm(
     "containertemplates.project_delete",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )
 
 # Allow duplicating project-wide templates.
 rules.add_perm(
     "containertemplates.project_duplicate",
-    pr_rules.is_project_owner
-    | pr_rules.is_project_delegate
-    | pr_rules.is_project_contributor,
+    pr_rules.can_modify_project_data
+    & (
+        pr_rules.is_project_owner
+        | pr_rules.is_project_delegate
+        | pr_rules.is_project_contributor
+    ),
 )

--- a/containertemplates/tests/test_permissions.py
+++ b/containertemplates/tests/test_permissions.py
@@ -347,3 +347,153 @@ class TestContainerTemplateProjectPermissions(ProjectPermissionTestBase):
         bad_users = [self.anonymous]
         self.assert_response(url, good_users, 200, method="POST", data=data)
         self.assert_response(url, bad_users, 302, method="POST", data=data)
+
+
+class TestContainerTemplateProjectPermissionsReadOnly(
+    ProjectPermissionTestBase
+):
+    """Test permissions for project-wide containertemplates app when site is in read-only mode."""
+
+    def setUp(self):
+        super().setUp()
+        self.containertemplateproject = ContainerTemplateProjectFactory(
+            project=self.project
+        )
+        self.set_site_read_only()
+        self.good_users = [self.superuser]
+        self.bad_users = [
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+            self.user_no_roles,
+            self.anonymous,
+            self.user_finder_cat,
+        ]
+
+    def test_containertemplateproject_list(self):
+        """Test permissions for the ``containertemplates:project-list`` view."""
+        url = reverse(
+            "containertemplates:project-list",
+            kwargs={"project": self.project.sodar_uuid},
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(url, good_users, 200)
+        self.assert_response(url, bad_users, 302)
+
+    def test_containertemplateproject_create(self):
+        """Test permissions for the ``containertemplates:project-create`` view."""
+        url = reverse(
+            "containertemplates:project-create",
+            kwargs={"project": self.project.sodar_uuid},
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_containertemplateproject_update(self):
+        """Test permissions for the ``containertemplates:project-update`` view."""
+        url = reverse(
+            "containertemplates:project-update",
+            kwargs={
+                "containertemplateproject": self.containertemplateproject.sodar_uuid
+            },
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_containertemplateproject_detail(self):
+        """Test permissions for the ``containertemplates:project-detail`` view."""
+        url = reverse(
+            "containertemplates:project-detail",
+            kwargs={
+                "containertemplateproject": self.containertemplateproject.sodar_uuid
+            },
+        )
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        bad_users = [self.user_no_roles, self.anonymous, self.user_finder_cat]
+        self.assert_response(url, good_users, 200)
+        self.assert_response(url, bad_users, 302)
+
+    def test_containertemplateproject_delete(self):
+        """Test permissions for the ``containertemplates:project-delete`` view."""
+        url = reverse(
+            "containertemplates:project-delete",
+            kwargs={
+                "containertemplateproject": self.containertemplateproject.sodar_uuid
+            },
+        )
+        self.assert_response(url, self.good_users, 200)
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_containertemplateproject_duplicate(self):
+        """Test permissions for the ``containertemplates:project-duplicate`` view."""
+        url = reverse(
+            "containertemplates:project-duplicate",
+            kwargs={
+                "containertemplateproject": self.containertemplateproject.sodar_uuid
+            },
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containertemplates:project-list",
+                kwargs={"project": self.project.sodar_uuid},
+            ),
+        )
+        self.assert_response(url, self.bad_users, 302)
+
+    def test_containertemplateproject_copy(self):
+        """Test permissions for the ``containertemplates:project-copy`` view."""
+        url = reverse(
+            "containertemplates:project-copy",
+            kwargs={"project": self.project.sodar_uuid},
+        )
+        self.assert_response(
+            url,
+            self.good_users,
+            302,
+            redirect_user=reverse(
+                "containertemplates:project-list",
+                kwargs={"project": self.project.sodar_uuid},
+            ),
+            method="POST",
+        )
+        self.assert_response(url, self.bad_users, 302, method="POST")
+
+    def test_containertemplate_ajax_get(self):
+        """Test permissions for the ``containertemplates:ajax-get-containertemplate`` view."""
+        url = reverse(
+            "containertemplates:ajax-get-containertemplate",
+        )
+        containertemplate = ContainerTemplateSiteFactory()
+        data = {
+            "containertemplate_id": containertemplate.id,
+            "site_or_project": "site",
+        }
+        good_users = [
+            self.superuser,
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+            self.user_no_roles,
+            self.user_finder_cat,
+        ]
+        bad_users = [self.anonymous]
+        self.assert_response(url, good_users, 200, method="POST", data=data)
+        self.assert_response(url, bad_users, 302, method="POST", data=data)


### PR DESCRIPTION
This PR ensures that read-only mode is supported by kiosc apps (see #179). In particular, when a site is in RO mode it is not possible to start/stop/pause/unpause/create/delete/edit containers or containertemplates (except for the superuser).