### PR TITLE
Use prettier widget for json form field

### DIFF
--- a/containers/forms.py
+++ b/containers/forms.py
@@ -1,9 +1,20 @@
+import json
+
 from django import forms
 from django.conf import settings
+from django.forms import widgets
 from django.urls import reverse
 
 from containers.models import Container, MASKED_KEYWORD
 from filesfolders.models import File
+
+
+class PrettyJSONWidget(widgets.Textarea):
+    def format_value(self, value):
+        try:
+            return json.dumps(json.loads(value), indent=2, sort_keys=False)
+        except Exception:
+            return super().format_value(value)
 
 
 class ContainerForm(forms.ModelForm):
@@ -37,6 +48,7 @@ class ContainerForm(forms.ModelForm):
         self.fields["project"].widget = forms.HiddenInput()
         self.fields["containertemplatesite"].widget = forms.HiddenInput()
         self.fields["containertemplateproject"].widget = forms.HiddenInput()
+        self.fields["environment"].widget = PrettyJSONWidget()
 
         # Hide host port if in docker-shared mode
         if settings.KIOSC_NETWORK_MODE == "docker-shared":

--- a/containers/models.py
+++ b/containers/models.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 
 from bgjobs.models import BackgroundJob, JobModelMessageMixin, LOG_LEVEL_DEBUG
 from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import JSONField
 from django.db import models, transaction
 from django.urls import reverse
@@ -299,7 +300,10 @@ class Container(models.Model):
     #: Define the environment variables to use, as an array of dicts with keys "name" and "value".
     #: This guarantees that the order of environment variable definitions does not change.
     environment = JSONField(
-        help_text="The environment variables to use", blank=True, null=True
+        help_text="The environment variables to use",
+        blank=True,
+        null=True,
+        encoder=DjangoJSONEncoder,
     )
 
     #: List if keys that when defined in ``environment`` are set but no displayed.


### PR DESCRIPTION
This PR adds a very basic fix for #138. The widget for JSON fields in the `ContainerUpdateView` now simply pretty-prints the JSON with some indentation.