### PR TITLE
Implement search for containers, background jobs, and logs

### DIFF
--- a/containers/models.py
+++ b/containers/models.py
@@ -6,6 +6,7 @@ from typing import Optional
 from bgjobs.models import BackgroundJob, JobModelMessageMixin, LOG_LEVEL_DEBUG
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
+from django.core.exceptions import ValidationError
 from django.db.models import JSONField
 from django.db import models, transaction
 from django.db.models import Q, QuerySet
@@ -184,19 +185,21 @@ class ContainerManager(models.Manager):
             term_query.add(Q(title__icontains=t), Q.OR)
             term_query.add(Q(description__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace('-', ''))
+                uuid.UUID(t.replace("-", ""))
                 term_query.add(Q(sodar_uuid=t), Q.OR)
             except ValueError:
                 pass
-        if keywords and 'project' in keywords:
+        if keywords and "project" in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords['project'])
-                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+                project = Project.objects.get(sodar_uuid=keywords["project"])
+                term_query.add(
+                    Q(project__full_title__startswith=project.full_title), Q.AND
+                )
             except Project.DoesNotExist:
                 return Container.objects.none()
             except ValidationError:
                 return Container.objects.none()
-        return super().get_queryset().filter(term_query).order_by('title')
+        return super().get_queryset().filter(term_query).order_by("title")
 
 
 class Container(models.Model):
@@ -464,19 +467,26 @@ class ContainerBackgroundJobManager(models.Manager):
             term_query.add(Q(container__title__icontains=t), Q.OR)
             term_query.add(Q(container__description__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace('-', ''))
+                uuid.UUID(t.replace("-", ""))
                 term_query.add(Q(sodar_uuid=t), Q.OR)
             except ValueError:
                 pass
-        if keywords and 'project' in keywords:
+        if keywords and "project" in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords['project'])
-                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+                project = Project.objects.get(sodar_uuid=keywords["project"])
+                term_query.add(
+                    Q(project__full_title__startswith=project.full_title), Q.AND
+                )
             except Project.DoesNotExist:
                 return Container.objects.none()
             except ValidationError:
                 return Container.objects.none()
-        return super().get_queryset().filter(term_query).order_by('container__title')
+        return (
+            super()
+            .get_queryset()
+            .filter(term_query)
+            .order_by("container__title")
+        )
 
 
 class ContainerBackgroundJob(JobModelMessageContextManagerMixin, models.Model):
@@ -595,19 +605,26 @@ class ContainerLogEntryManager(models.Manager):
             term_query.add(Q(text__icontains=t), Q.OR)
             term_query.add(Q(process__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace('-', ''))
+                uuid.UUID(t.replace("-", ""))
                 term_query.add(Q(sodar_uuid=t), Q.OR)
             except ValueError:
                 pass
-        if keywords and 'project' in keywords:
+        if keywords and "project" in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords['project'])
-                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+                project = Project.objects.get(sodar_uuid=keywords["project"])
+                term_query.add(
+                    Q(project__full_title__startswith=project.full_title), Q.AND
+                )
             except Project.DoesNotExist:
                 return Container.objects.none()
             except ValidationError:
                 return Container.objects.none()
-        return super().get_queryset().filter(term_query).order_by('container', '-date_created')
+        return (
+            super()
+            .get_queryset()
+            .filter(term_query)
+            .order_by("container", "-date_created")
+        )
 
 
 class ContainerLogEntry(models.Model):

--- a/containers/models.py
+++ b/containers/models.py
@@ -188,9 +188,9 @@ class ContainerManager(models.Manager):
                 term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
-        if keywords and "project" in keywords:
+        if keywords and 'project' in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords["project"])
+                project = Project.objects.get(sodar_uuid=keywords['project'])
                 term_query.add(
                     Q(project__full_title__startswith=project.full_title), Q.AND
                 )
@@ -198,7 +198,7 @@ class ContainerManager(models.Manager):
                 return Container.objects.none()
             except ValidationError:
                 return Container.objects.none()
-        return super().get_queryset().filter(term_query).order_by("title")
+        return super().get_queryset().filter(term_query).order_by('title')
 
 
 class Container(models.Model):
@@ -469,9 +469,9 @@ class ContainerBackgroundJobManager(models.Manager):
                 term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
-        if keywords and "project" in keywords:
+        if keywords and 'project' in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords["project"])
+                project = Project.objects.get(sodar_uuid=keywords['project'])
                 term_query.add(
                     Q(project__full_title__startswith=project.full_title), Q.AND
                 )
@@ -483,7 +483,7 @@ class ContainerBackgroundJobManager(models.Manager):
             super()
             .get_queryset()
             .filter(term_query)
-            .order_by("container__title")
+            .order_by('container__title')
         )
 
 
@@ -606,9 +606,9 @@ class ContainerLogEntryManager(models.Manager):
                 term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
-        if keywords and "project" in keywords:
+        if keywords and 'project' in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords["project"])
+                project = Project.objects.get(sodar_uuid=keywords['project'])
                 term_query.add(
                     Q(project__full_title__startswith=project.full_title), Q.AND
                 )
@@ -620,7 +620,7 @@ class ContainerLogEntryManager(models.Manager):
             super()
             .get_queryset()
             .filter(term_query)
-            .order_by("container", "-date_created")
+            .order_by('container', '-date_created')
         )
 
 

--- a/containers/models.py
+++ b/containers/models.py
@@ -1,12 +1,14 @@
 import contextlib
 import uuid
 from datetime import timedelta
+from typing import Optional
 
 from bgjobs.models import BackgroundJob, JobModelMessageMixin, LOG_LEVEL_DEBUG
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import JSONField
 from django.db import models, transaction
+from django.db.models import Q, QuerySet
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.timezone import localtime
@@ -161,6 +163,40 @@ class JobModelMessageContextManagerMixin(JobModelMessageMixin):
             raise e
         else:
             self.mark_success()
+
+
+class ContainerManager(models.Manager):
+    """Manager for custom container queries"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return containers matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of Container objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(repository__icontains=t), Q.OR)
+            term_query.add(Q(title__icontains=t), Q.OR)
+            term_query.add(Q(description__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace('-', ''))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        if keywords and 'project' in keywords:
+            try:
+                project = Project.objects.get(sodar_uuid=keywords['project'])
+                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+            except Project.DoesNotExist:
+                return Container.objects.none()
+            except ValidationError:
+                return Container.objects.none()
+        return super().get_queryset().filter(term_query).order_by('title')
 
 
 class Container(models.Model):
@@ -368,6 +404,9 @@ class Container(models.Model):
         default=settings.KIOSC_DOCKER_MAX_INACTIVITY,
     )
 
+    # Set manager for custom queries
+    objects = ContainerManager()
+
     def __str__(self):
         return f'{self.title} [{self.state}]'
 
@@ -404,6 +443,40 @@ class Container(models.Model):
             key: (MASKED_KEYWORD if key in secret_keys else value)
             for key, value in self.environment.items()
         }
+
+
+class ContainerBackgroundJobManager(models.Manager):
+    """Manager for custom container-related background job queries"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container background jobs whose container matches the query.
+
+        :param search_terms: Search terms for containers (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of ContainerBackgroundJob objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(container__repository__icontains=t), Q.OR)
+            term_query.add(Q(container__title__icontains=t), Q.OR)
+            term_query.add(Q(container__description__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace('-', ''))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        if keywords and 'project' in keywords:
+            try:
+                project = Project.objects.get(sodar_uuid=keywords['project'])
+                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+            except Project.DoesNotExist:
+                return Container.objects.none()
+            except ValidationError:
+                return Container.objects.none()
+        return super().get_queryset().filter(term_query).order_by('container__title')
 
 
 class ContainerBackgroundJob(JobModelMessageContextManagerMixin, models.Model):
@@ -457,6 +530,9 @@ class ContainerBackgroundJob(JobModelMessageContextManagerMixin, models.Model):
         on_delete=models.CASCADE,
     )
 
+    # Set manager for custom queries
+    objects = ContainerBackgroundJobManager()
+
 
 class ContainerLogEntryManager(models.Manager):
     def merge_order(self, *args, **kwargs):
@@ -503,6 +579,35 @@ class ContainerLogEntryManager(models.Manager):
             return None
 
         return obj.get_date_docker_log()
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container log entries matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of ContainerLogEntry objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(text__icontains=t), Q.OR)
+            term_query.add(Q(process__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace('-', ''))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        if keywords and 'project' in keywords:
+            try:
+                project = Project.objects.get(sodar_uuid=keywords['project'])
+                term_query.add(Q(project__full_title__startswith=project.full_title), Q.AND)
+            except Project.DoesNotExist:
+                return Container.objects.none()
+            except ValidationError:
+                return Container.objects.none()
+        return super().get_queryset().filter(term_query).order_by('container', '-date_created')
 
 
 class ContainerLogEntry(models.Model):

--- a/containers/models.py
+++ b/containers/models.py
@@ -185,8 +185,7 @@ class ContainerManager(models.Manager):
             term_query.add(Q(title__icontains=t), Q.OR)
             term_query.add(Q(description__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace("-", ""))
-                term_query.add(Q(sodar_uuid=t), Q.OR)
+                term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
         if keywords and "project" in keywords:
@@ -467,8 +466,7 @@ class ContainerBackgroundJobManager(models.Manager):
             term_query.add(Q(container__title__icontains=t), Q.OR)
             term_query.add(Q(container__description__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace("-", ""))
-                term_query.add(Q(sodar_uuid=t), Q.OR)
+                term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
         if keywords and "project" in keywords:
@@ -605,8 +603,7 @@ class ContainerLogEntryManager(models.Manager):
             term_query.add(Q(text__icontains=t), Q.OR)
             term_query.add(Q(process__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace("-", ""))
-                term_query.add(Q(sodar_uuid=t), Q.OR)
+                term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
         if keywords and "project" in keywords:

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -95,7 +95,12 @@ class ProjectAppPlugin(
     search_enable = True
 
     #: List of search object types for the app
-    search_types = ["container", "containerbackgroundjob", "containerlogentry"]
+    search_types = [
+        "container",
+        "containerbackgroundjob",
+        "containerlogentry",
+        "containertemplate",
+    ]
 
     #: Search results template
     search_template = 'containers/_search_results.html'
@@ -300,6 +305,12 @@ class ProjectAppPlugin(
         items = []
         if not search_type:
             containers = Container.objects.find(search_terms, keywords)
+            container_templates_project = ContainerTemplateProject.objects.find(
+                search_terms, keywords
+            )
+            container_templates_site = ContainerTemplateSite.objects.find(
+                search_terms, keywords
+            )
             container_bg_jobs = ContainerBackgroundJob.objects.find(
                 search_terms, keywords
             )
@@ -308,31 +319,44 @@ class ProjectAppPlugin(
             )
             items = (
                 list(containers)
+                + list(container_templates_project)
+                + list(container_templates_site)
                 + list(container_bg_jobs)
                 + list(container_logs)
             )
             # items.sort(key=lambda x: x.title.lower())
         elif search_type == "container":
             items = Container.objects.find(search_terms, keywords)
+        elif search_type == "containertemplate":
+            container_templates_project = ContainerTemplateProject.objects.find(
+                search_terms, keywords
+            )
+            container_templates_site = ContainerTemplateSite.objects.find(
+                search_terms, keywords
+            )
+            items = list(container_templates_project) + list(
+                container_templates_site
+            )
         elif search_type == "containerbackgroundjob":
             items = ContainerBackgroundJob.objects.find(search_terms, keywords)
         elif search_type == "containerlogentry":
             items = ContainerLogEntry.objects.find(search_terms, keywords)
-        if items:
-            items = [
-                x
-                for x in items
-                if (
-                    isinstance(x, Container)
-                    and user.has_perm("containers.view_container", x.project)
-                )
-                or (
-                    not isinstance(x, Container)
-                    and user.has_perm(
-                        "containers.view_container", x.container.project
-                    )
-                )
-            ]
+        filtered_items = []
+        for item in items:
+            if (
+                isinstance(item, Container)
+                or isinstance(item, ContainerTemplateProject)
+            ) and user.has_perm("containers.view_container", item.project):
+                filtered_items.append(item)
+            elif (
+                isinstance(item, ContainerBackgroundJob)
+                or isinstance(item, ContainerLogEntry)
+            ) and user.has_perm(
+                "containers.view_container", item.container.project
+            ):
+                filtered_items.append(item)
+            elif isinstance(item, ContainerTemplateSite):
+                filtered_items.append(item)
         ret = PluginSearchResult(
             category="all",
             title="Containers, Background Jobs, and Logs",
@@ -341,6 +365,6 @@ class ProjectAppPlugin(
                 "containerbackgroundjob",
                 "containerlogentry",
             ],
-            items=items,
+            items=filtered_items,
         )
         return [ret]

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -2,6 +2,7 @@
 
 from typing import Optional, Union
 from uuid import UUID
+import logging
 
 # Projectroles dependency
 from django.contrib.auth import get_user_model
@@ -31,6 +32,7 @@ from containertemplates.models import (
 
 
 User = get_user_model()
+logger = logging.getLogger(__name__)
 
 PROJECT_TYPE_PROJECT = SODAR_CONSTANTS['PROJECT_TYPE_PROJECT']
 
@@ -295,6 +297,9 @@ class ProjectAppPlugin(
         Return container items based on one or more search terms, user, optional
         type and optional keywords.
 
+        NOTE: this method is also responsible for searching ContainerTemplate
+        objects.
+
         :param search_terms: Search terms to be joined with the OR operator
                              (list of strings)
         :param user: User object for user initiating the search
@@ -303,60 +308,36 @@ class ProjectAppPlugin(
         :return: List of PluginSearchResult objects
         """
         items = []
-        if not search_type:
-            containers = Container.objects.find(search_terms, keywords)
-            container_templates_project = ContainerTemplateProject.objects.find(
-                search_terms, keywords
+        if not search_type or search_type == "container":
+            items.extend(Container.objects.find(search_terms, keywords))
+        if not search_type or search_type == "containertemplate":
+            items.extend(
+                ContainerTemplateProject.objects.find(search_terms, keywords)
             )
-            container_templates_site = ContainerTemplateSite.objects.find(
-                search_terms, keywords
+            items.extend(
+                ContainerTemplateSite.objects.find(search_terms, keywords)
             )
-            container_bg_jobs = ContainerBackgroundJob.objects.find(
-                search_terms, keywords
+        if not search_type or search_type == "containerbackgroundjob":
+            items.extend(
+                ContainerBackgroundJob.objects.find(search_terms, keywords)
             )
-            container_logs = ContainerLogEntry.objects.find(
-                search_terms, keywords
-            )
-            items = (
-                list(containers)
-                + list(container_templates_project)
-                + list(container_templates_site)
-                + list(container_bg_jobs)
-                + list(container_logs)
-            )
-            # items.sort(key=lambda x: x.title.lower())
-        elif search_type == "container":
-            items = Container.objects.find(search_terms, keywords)
-        elif search_type == "containertemplate":
-            container_templates_project = ContainerTemplateProject.objects.find(
-                search_terms, keywords
-            )
-            container_templates_site = ContainerTemplateSite.objects.find(
-                search_terms, keywords
-            )
-            items = list(container_templates_project) + list(
-                container_templates_site
-            )
-        elif search_type == "containerbackgroundjob":
-            items = ContainerBackgroundJob.objects.find(search_terms, keywords)
-        elif search_type == "containerlogentry":
-            items = ContainerLogEntry.objects.find(search_terms, keywords)
+        if not search_type or search_type == "containerlogentry":
+            items.extend(ContainerLogEntry.objects.find(search_terms, keywords))
         filtered_items = []
         for item in items:
-            if (
-                isinstance(item, Container)
-                or isinstance(item, ContainerTemplateProject)
-            ) and user.has_perm("containers.view_container", item.project):
-                filtered_items.append(item)
-            elif (
-                isinstance(item, ContainerBackgroundJob)
-                or isinstance(item, ContainerLogEntry)
-            ) and user.has_perm(
-                "containers.view_container", item.container.project
-            ):
-                filtered_items.append(item)
-            elif isinstance(item, ContainerTemplateSite):
-                filtered_items.append(item)
+            match item:
+                case ContainerTemplateSite():
+                    filtered_items.append(item)
+                case Container() | ContainerTemplateProject():
+                    if user.has_perm("containers.view_container", item.project):
+                        filtered_items.append(item)
+                case ContainerBackgroundJob() | ContainerLogEntry():
+                    if user.has_perm(
+                        "containers.view_container", item.container.project
+                    ):
+                        filtered_items.append(item)
+                case _:
+                    logger.debug(f"Unexpected search result: {item}")
         ret = PluginSearchResult(
             category="all",
             title="Containers, Background Jobs, and Logs",

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -16,7 +16,11 @@ from projectroles.plugins import (
     ProjectModifyPluginMixin,
 )
 
-from containers.models import Container, ContainerBackgroundJob, ContainerLogEntry
+from containers.models import (
+    Container,
+    ContainerBackgroundJob,
+    ContainerLogEntry,
+)
 from containers.urls import urlpatterns
 from containers.views import ContainerModifyMixin
 
@@ -296,26 +300,40 @@ class ProjectAppPlugin(
         items = []
         if not search_type:
             containers = Container.objects.find(search_terms, keywords)
-            container_bg_jobs = ContainerBackgroundJob.objects.find(search_terms, keywords)
-            container_logs = ContainerLogEntry.objects.find(search_terms, keywords)
-            items = list(containers) + list(container_bg_jobs) + list(container_logs)
+            container_bg_jobs = ContainerBackgroundJob.objects.find(
+                search_terms, keywords
+            )
+            container_logs = ContainerLogEntry.objects.find(
+                search_terms, keywords
+            )
+            items = (
+                list(containers)
+                + list(container_bg_jobs)
+                + list(container_logs)
+            )
             # items.sort(key=lambda x: x.title.lower())
-        elif search_type == 'container':
+        elif search_type == "container":
             items = Container.objects.find(search_terms, keywords)
-        elif search_type == 'containerbackgroundjob':
+        elif search_type == "containerbackgroundjob":
             items = ContainerBackgroundJob.objects.find(search_terms, keywords)
-        elif search_type == 'containerlogentry':
+        elif search_type == "containerlogentry":
             items = ContainerLogEntry.objects.find(search_terms, keywords)
         if items:
             items = [
                 x
                 for x in items
-                if isinstance(x, Container) and user.has_perm('containers.view_container', x) or user.has_perm('containers.view_container', x.container)
+                if isinstance(x, Container)
+                and user.has_perm("containers.view_container", x)
+                or user.has_perm("containers.view_container", x.container)
             ]
         ret = PluginSearchResult(
-            category='all',
-            title='Containers, Background Jobs, and Logs',
-            search_types=['container', 'containerbackgroundjob', 'containerlogentry'],
+            category="all",
+            title="Containers, Background Jobs, and Logs",
+            search_types=[
+                "container",
+                "containerbackgroundjob",
+                "containerlogentry",
+            ],
             items=items,
         )
         return [ret]

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -322,9 +322,16 @@ class ProjectAppPlugin(
             items = [
                 x
                 for x in items
-                if isinstance(x, Container)
-                and user.has_perm("containers.view_container", x)
-                or user.has_perm("containers.view_container", x.container)
+                if (
+                    isinstance(x, Container)
+                    and user.has_perm("containers.view_container", x.project)
+                )
+                or (
+                    not isinstance(x, Container)
+                    and user.has_perm(
+                        "containers.view_container", x.container.project
+                    )
+                )
             ]
         ret = PluginSearchResult(
             category="all",

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -12,10 +12,11 @@ from projectroles.plugins import (
     ProjectAppPluginPoint,
     PluginObjectLink,
     PluginCategoryStatistic,
+    PluginSearchResult,
     ProjectModifyPluginMixin,
 )
 
-from containers.models import Container
+from containers.models import Container, ContainerBackgroundJob, ContainerLogEntry
 from containers.urls import urlpatterns
 from containers.views import ContainerModifyMixin
 
@@ -90,7 +91,7 @@ class ProjectAppPlugin(
     search_enable = True
 
     #: List of search object types for the app
-    search_types = ['source', 'sample', 'file']
+    search_types = ["container", "containerbackgroundjob", "containerlogentry"]
 
     #: Search results template
     search_template = 'containers/_search_results.html'
@@ -273,3 +274,48 @@ class ProjectAppPlugin(
         user = project.get_owner().user
         for container in containers:
             self._container_delete_docker(container, user)
+
+    def search(
+        self,
+        search_terms: list[str],
+        user: User,
+        search_type: Optional[str] = None,
+        keywords: Optional[list[str]] = None,
+    ) -> list[PluginSearchResult]:
+        """
+        Return container items based on one or more search terms, user, optional
+        type and optional keywords.
+
+        :param search_terms: Search terms to be joined with the OR operator
+                             (list of strings)
+        :param user: User object for user initiating the search
+        :param search_type: Type of objects to be searched (String)
+        :param keywords: Dictionary of key/value pairs (optional)
+        :return: List of PluginSearchResult objects
+        """
+        items = []
+        if not search_type:
+            containers = Container.objects.find(search_terms, keywords)
+            container_bg_jobs = ContainerBackgroundJob.objects.find(search_terms, keywords)
+            container_logs = ContainerLogEntry.objects.find(search_terms, keywords)
+            items = list(containers) + list(container_bg_jobs) + list(container_logs)
+            # items.sort(key=lambda x: x.title.lower())
+        elif search_type == 'container':
+            items = Container.objects.find(search_terms, keywords)
+        elif search_type == 'containerbackgroundjob':
+            items = ContainerBackgroundJob.objects.find(search_terms, keywords)
+        elif search_type == 'containerlogentry':
+            items = ContainerLogEntry.objects.find(search_terms, keywords)
+        if items:
+            items = [
+                x
+                for x in items
+                if isinstance(x, Container) and user.has_perm('containers.view_container', x) or user.has_perm('containers.view_container', x.container)
+            ]
+        ret = PluginSearchResult(
+            category='all',
+            title='Containers, Background Jobs, and Logs',
+            search_types=['container', 'containerbackgroundjob', 'containerlogentry'],
+            items=items,
+        )
+        return [ret]

--- a/containers/plugins.py
+++ b/containers/plugins.py
@@ -98,10 +98,10 @@ class ProjectAppPlugin(
 
     #: List of search object types for the app
     search_types = [
-        "container",
-        "containerbackgroundjob",
-        "containerlogentry",
-        "containertemplate",
+        'container',
+        'containerbackgroundjob',
+        'containerlogentry',
+        'containertemplate',
     ]
 
     #: Search results template
@@ -308,20 +308,20 @@ class ProjectAppPlugin(
         :return: List of PluginSearchResult objects
         """
         items = []
-        if not search_type or search_type == "container":
+        if not search_type or search_type == 'container':
             items.extend(Container.objects.find(search_terms, keywords))
-        if not search_type or search_type == "containertemplate":
+        if not search_type or search_type == 'containertemplate':
             items.extend(
                 ContainerTemplateProject.objects.find(search_terms, keywords)
             )
             items.extend(
                 ContainerTemplateSite.objects.find(search_terms, keywords)
             )
-        if not search_type or search_type == "containerbackgroundjob":
+        if not search_type or search_type == 'containerbackgroundjob':
             items.extend(
                 ContainerBackgroundJob.objects.find(search_terms, keywords)
             )
-        if not search_type or search_type == "containerlogentry":
+        if not search_type or search_type == 'containerlogentry':
             items.extend(ContainerLogEntry.objects.find(search_terms, keywords))
         filtered_items = []
         for item in items:
@@ -329,22 +329,22 @@ class ProjectAppPlugin(
                 case ContainerTemplateSite():
                     filtered_items.append(item)
                 case Container() | ContainerTemplateProject():
-                    if user.has_perm("containers.view_container", item.project):
+                    if user.has_perm('containers.view_container', item.project):
                         filtered_items.append(item)
                 case ContainerBackgroundJob() | ContainerLogEntry():
                     if user.has_perm(
-                        "containers.view_container", item.container.project
+                        'containers.view_container', item.container.project
                     ):
                         filtered_items.append(item)
                 case _:
-                    logger.debug(f"Unexpected search result: {item}")
+                    logger.debug(f'Unexpected search result: {item}')
         ret = PluginSearchResult(
-            category="all",
-            title="Containers, Background Jobs, and Logs",
+            category='all',
+            title='Containers, Background Jobs, and Logs',
             search_types=[
-                "container",
-                "containerbackgroundjob",
-                "containerlogentry",
+                'container',
+                'containerbackgroundjob',
+                'containerlogentry',
             ],
             items=filtered_items,
         )

--- a/containers/templates/containers/_search_item.html
+++ b/containers/templates/containers/_search_item.html
@@ -1,0 +1,45 @@
+{% load container_tags %}
+{# Projectroles dependency #}
+{% load projectroles_common_tags %}
+
+<tr class="sodar-containers-search-item" id="sodar-containers-search-item-{{ item.sodar_uuid }}">
+  {# Type #}
+  <td class="text-nowrap">
+    {{ item|get_class }}
+  </td>
+  {# Project column #}
+  <td>
+    {# NOTE: No highlight here as project is not searched for here #}
+    {% autoescape off %}
+      {% if item|get_class == 'ContainerLogEntry' %}
+        {{ item.container.project.title }}
+      {% else %}
+        {{ item.project.title }}
+      {% endif %}
+    {% endautoescape %}
+  </td>
+  {# Container #}
+  <td>
+    {% autoescape off %}
+      {% if item|get_class == 'Container' %}
+        {% highlight_search_term item.title search_terms %}
+        ({% highlight_search_term item.repository search_terms %}:{{ item.tag }})
+      {% else %}
+        {% highlight_search_term item.container.title search_terms %}
+        ({% highlight_search_term item.container.repository search_terms %}:{{ item.container.tag }})
+      {% endif %}
+    {% endautoescape %}
+  </td>
+  {# Description #}
+  <td>
+    {% autoescape off %}
+      {% if item|get_class == 'Container' %}
+        {% highlight_search_term item.description search_terms %}
+      {% elif item|get_class == 'ContainerBackgroundJob' %}
+        {% highlight_search_term item.container.description search_terms %}
+      {% elif item|get_class == 'ContainerLogEntry' %}
+        {% highlight_search_term item.text search_terms %}
+      {% endif %}
+    {% endautoescape %}
+  </td>
+</tr>

--- a/containers/templates/containers/_search_item.html
+++ b/containers/templates/containers/_search_item.html
@@ -36,7 +36,7 @@
       {% if item|get_class == 'Container' %}
         {% highlight_search_term item.description search_terms %}
       {% elif item|get_class == 'ContainerBackgroundJob' %}
-        {% highlight_search_term item.container.description search_terms %}
+        {{ item.action }}
       {% elif item|get_class == 'ContainerLogEntry' %}
         {% highlight_search_term item.text search_terms %}
       {% endif %}

--- a/containers/templates/containers/_search_item.html
+++ b/containers/templates/containers/_search_item.html
@@ -21,7 +21,7 @@
   {# Container #}
   <td>
     {% autoescape off %}
-      {% if item|get_class == 'Container' %}
+      {% if item|get_class == 'Container' or item|get_class == 'ContainerTemplateProject' or item|get_class == 'ContainerTemplateSite' %}
         {% highlight_search_term item.title search_terms %}
         ({% highlight_search_term item.repository search_terms %}:{{ item.tag }})
       {% else %}

--- a/containers/templates/containers/_search_item.html
+++ b/containers/templates/containers/_search_item.html
@@ -11,7 +11,7 @@
   <td>
     {# NOTE: No highlight here as project is not searched for here #}
     {% autoescape off %}
-      {% if item|get_class == 'ContainerLogEntry' %}
+      {% if item|get_class == "ContainerLogEntry" %}
         {{ item.container.project.title }}
       {% else %}
         {{ item.project.title }}
@@ -21,24 +21,28 @@
   {# Container #}
   <td>
     {% autoescape off %}
-      {% if item|get_class == 'Container' or item|get_class == 'ContainerTemplateProject' or item|get_class == 'ContainerTemplateSite' %}
+      {% if item|get_class == "Container" or item|get_class == "ContainerTemplateProject" or item|get_class == "ContainerTemplateSite" %}
         {% highlight_search_term item.title search_terms %}
         ({% highlight_search_term item.repository search_terms %}:{{ item.tag }})
-      {% else %}
+      {% elif item|get_class == "ContainerBackgroundJob" or item|get_class == "ContainerLogEntry" %}
         {% highlight_search_term item.container.title search_terms %}
         ({% highlight_search_term item.container.repository search_terms %}:{{ item.container.tag }})
+      {% else %}
+        Object of class {{ item|get_class }}
       {% endif %}
     {% endautoescape %}
   </td>
   {# Description #}
   <td>
     {% autoescape off %}
-      {% if item|get_class == 'Container' %}
+      {% if item|get_class == "Container" or item|get_class == "ContainerTemplateProject" or item|get_class == "ContainerTemplateSite" %}
         {% highlight_search_term item.description search_terms %}
-      {% elif item|get_class == 'ContainerBackgroundJob' %}
+      {% elif item|get_class == "ContainerBackgroundJob" %}
         {{ item.action }}
-      {% elif item|get_class == 'ContainerLogEntry' %}
+      {% elif item|get_class == "ContainerLogEntry" %}
         {% highlight_search_term item.text search_terms %}
+      {% else %}
+        Object of class {{ item|get_class }}
       {% endif %}
     {% endautoescape %}
   </td>

--- a/containers/templates/containers/_search_results.html
+++ b/containers/templates/containers/_search_results.html
@@ -1,0 +1,26 @@
+{% load rules %}
+{% load container_tags %}
+
+{# Projectroles dependency #}
+{% load projectroles_common_tags %}
+
+{% if search_results.all.items|length > 0 %}
+  {% include 'projectroles/_search_header.html' with search_title=search_results.all.title result_count=search_results.all.items|length %}
+  <table class="table table-striped sodar-card-table sodar-search-table"
+         id="sodar-containers-search-table">
+    <thead>
+      <tr>
+        <th>Type</th>
+        <th>{% get_display_name 'PROJECT' title=True %}</th>
+        <th>Container</th>
+        <th>Description</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for item in search_results.all.items %}
+        {% include 'containers/_search_item.html' with item=item %}
+      {% endfor %}
+    </tbody>
+  </table>
+  {% include 'projectroles/_search_footer.html' %}
+{% endif %}

--- a/containers/templatetags/container_tags.py
+++ b/containers/templatetags/container_tags.py
@@ -46,6 +46,11 @@ def state_bell(state, last_action):
 
 
 @register.filter
+def get_class(item):
+    return item.__class__.__name__
+
+
+@register.filter
 def pretty_json(obj):
     return json.dumps(obj, indent=4, sort_keys=True)
 

--- a/containers/tests/test_permissions.py
+++ b/containers/tests/test_permissions.py
@@ -14,7 +14,7 @@ from containers.tests.factories import (
 )
 
 
-PROJECT_TYPE_PROJECT = SODAR_CONSTANTS["PROJECT_TYPE_PROJECT"]
+PROJECT_TYPE_PROJECT = SODAR_CONSTANTS['PROJECT_TYPE_PROJECT']
 
 
 responses = Responses('requests.packages.urllib3')
@@ -613,10 +613,10 @@ class TestSearchPermissions(ProjectPermissionTestBase):
     def setUp(self):
         super().setUp()
         self.other_project = self.make_project(
-            "other_project",
+            'other_project',
             PROJECT_TYPE_PROJECT,
             self.category,
-            description="description",
+            description='description',
         )
         self.container = ContainerFactory(project=self.project)
         self.other_container = ContainerFactory(project=self.other_project)
@@ -632,7 +632,7 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         self.make_assignment(
             self.other_project, self.user_finder_cat, self.role_guest
         )
-        self.url = reverse("projectroles:search")
+        self.url = reverse('projectroles:search')
         self.good_users = [
             self.user_owner,
             self.user_delegate,
@@ -646,19 +646,19 @@ class TestSearchPermissions(ProjectPermissionTestBase):
             res = self.client.get(self.url, data)
             context = res.context
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(context["search_input"], data["s"])
-        for app in context["app_results"]:
-            if app["plugin"].name == "containers":
-                return app["results"]
+        self.assertEqual(context['search_input'], data['s'])
+        for app in context['app_results']:
+            if app['plugin'].name == 'containers':
+                return app['results']
 
     def test_search_term(self):
         """Test permissions for search view."""
-        data = {"s": "repository"}
+        data = {'s': 'repository'}
 
         # Superuser sees everything
         results = self._get_search_results(self.superuser, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set(
                 [
                     self.container,
@@ -673,18 +673,18 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         for user in self.good_users:
             results = self._get_search_results(user, data)
             self.assertEqual(
-                results["all"].items, [self.container, self.bg_job]
+                results['all'].items, [self.container, self.bg_job]
             )
 
         # Bad users should not see any results
         for user in self.bad_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [])
+            self.assertEqual(results['all'].items, [])
 
         # Special users
         results = self._get_search_results(self.user_contributor_cat, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set(
                 [
                     self.container,
@@ -696,7 +696,7 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         )
         results = self._get_search_results(self.user_finder_cat, data)
         self.assertEqual(
-            results["all"].items, [self.other_container, self.other_bg_job]
+            results['all'].items, [self.other_container, self.other_bg_job]
         )
 
         # Anonymous
@@ -705,31 +705,31 @@ class TestSearchPermissions(ProjectPermissionTestBase):
 
     def test_search_term_with_type(self):
         """Test permissions for search view limited by type."""
-        data = {"s": "container type:containerbackgroundjob"}
+        data = {'s': 'container type:containerbackgroundjob'}
 
         # Superuser sees everything
         results = self._get_search_results(self.superuser, data)
         self.assertEqual(
-            set(results["all"].items), set([self.bg_job, self.other_bg_job])
+            set(results['all'].items), set([self.bg_job, self.other_bg_job])
         )
 
         # Good users see only the container in their project
         for user in self.good_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [self.bg_job])
+            self.assertEqual(results['all'].items, [self.bg_job])
 
         # Bad users should not see any results
         for user in self.bad_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [])
+            self.assertEqual(results['all'].items, [])
 
         # Special users
         results = self._get_search_results(self.user_contributor_cat, data)
         self.assertEqual(
-            set(results["all"].items), set([self.bg_job, self.other_bg_job])
+            set(results['all'].items), set([self.bg_job, self.other_bg_job])
         )
         results = self._get_search_results(self.user_finder_cat, data)
-        self.assertEqual(results["all"].items, [self.other_bg_job])
+        self.assertEqual(results['all'].items, [self.other_bg_job])
 
         # Anonymous
         res = self.client.get(self.url, data)
@@ -738,32 +738,32 @@ class TestSearchPermissions(ProjectPermissionTestBase):
     def test_search_term_with_type_and_keyword(self):
         """Test permissions for search view limited by type and project."""
         data = {
-            "s": (
-                "description "
-                "type:containerbackgroundjob "
-                f"project:{self.project.sodar_uuid}"
+            's': (
+                'description '
+                'type:containerbackgroundjob '
+                f'project:{self.project.sodar_uuid}'
             )
         }
 
         # Superuser sees everything
         results = self._get_search_results(self.superuser, data)
-        self.assertEqual(set(results["all"].items), set([self.bg_job]))
+        self.assertEqual(set(results['all'].items), set([self.bg_job]))
 
         # Good users see only the container in their project
         for user in self.good_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [self.bg_job])
+            self.assertEqual(results['all'].items, [self.bg_job])
 
         # Bad users should not see any results
         for user in self.bad_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [])
+            self.assertEqual(results['all'].items, [])
 
         # Special users
         results = self._get_search_results(self.user_contributor_cat, data)
-        self.assertEqual(set(results["all"].items), set([self.bg_job]))
+        self.assertEqual(set(results['all'].items), set([self.bg_job]))
         results = self._get_search_results(self.user_finder_cat, data)
-        self.assertEqual(results["all"].items, [])
+        self.assertEqual(results['all'].items, [])
 
         # Anonymous
         res = self.client.get(self.url, data)

--- a/containers/tests/test_permissions.py
+++ b/containers/tests/test_permissions.py
@@ -3,11 +3,18 @@
 from unittest.mock import patch
 
 from django.urls import reverse
+from projectroles.models import SODAR_CONSTANTS
 from projectroles.tests.base import ProjectPermissionTestBase
 from urllib3_mock import Responses
 
 from containers.models import STATE_RUNNING
-from containers.tests.factories import ContainerFactory
+from containers.tests.factories import (
+    ContainerFactory,
+    ContainerBackgroundJobFactory,
+)
+
+
+PROJECT_TYPE_PROJECT = SODAR_CONSTANTS["PROJECT_TYPE_PROJECT"]
 
 
 responses = Responses('requests.packages.urllib3')
@@ -598,3 +605,165 @@ class TestContainerPermissionReadOnly(ProjectPermissionTestBase):
             ),
         )
         self.assert_response(url, bad_users, 302)
+
+
+class TestSearchPermissions(ProjectPermissionTestBase):
+    """Test permissions for searching."""
+
+    def setUp(self):
+        super().setUp()
+        self.other_project = self.make_project(
+            "other_project",
+            PROJECT_TYPE_PROJECT,
+            self.category,
+            description="description",
+        )
+        self.container = ContainerFactory(project=self.project)
+        self.other_container = ContainerFactory(project=self.other_project)
+        self.bg_job = ContainerBackgroundJobFactory(
+            project=self.project, container=self.container, user=self.user_owner
+        )
+        self.other_bg_job = ContainerBackgroundJobFactory(
+            project=self.other_project,
+            container=self.other_container,
+            user=self.user_contributor_cat,
+        )
+        self.make_assignment(
+            self.other_project, self.user_finder_cat, self.role_guest
+        )
+        self.url = reverse("projectroles:search")
+        self.good_users = [
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
+        self.bad_users = [self.user_viewer, self.user_no_roles]
+
+    def _get_search_results(self, user, data):
+        with self.login(user):
+            res = self.client.get(self.url, data)
+            context = res.context
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(context["search_input"], data["s"])
+        for app in context["app_results"]:
+            if app["plugin"].name == "containers":
+                return app["results"]
+
+    def test_search_term(self):
+        """Test permissions for search view."""
+        data = {"s": "repository"}
+
+        # Superuser sees everything
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set(
+                [
+                    self.container,
+                    self.other_container,
+                    self.bg_job,
+                    self.other_bg_job,
+                ]
+            ),
+        )
+
+        # Good users see only the container in their project
+        for user in self.good_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(
+                results["all"].items, [self.container, self.bg_job]
+            )
+
+        # Bad users should not see any results
+        for user in self.bad_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [])
+
+        # Special users
+        results = self._get_search_results(self.user_contributor_cat, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set(
+                [
+                    self.container,
+                    self.other_container,
+                    self.bg_job,
+                    self.other_bg_job,
+                ]
+            ),
+        )
+        results = self._get_search_results(self.user_finder_cat, data)
+        self.assertEqual(
+            results["all"].items, [self.other_container, self.other_bg_job]
+        )
+
+        # Anonymous
+        res = self.client.get(self.url, data)
+        self.assertEqual(res.status_code, 302)
+
+    def test_search_term_with_type(self):
+        """Test permissions for search view limited by type."""
+        data = {"s": "container type:containerbackgroundjob"}
+
+        # Superuser sees everything
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(
+            set(results["all"].items), set([self.bg_job, self.other_bg_job])
+        )
+
+        # Good users see only the container in their project
+        for user in self.good_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [self.bg_job])
+
+        # Bad users should not see any results
+        for user in self.bad_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [])
+
+        # Special users
+        results = self._get_search_results(self.user_contributor_cat, data)
+        self.assertEqual(
+            set(results["all"].items), set([self.bg_job, self.other_bg_job])
+        )
+        results = self._get_search_results(self.user_finder_cat, data)
+        self.assertEqual(results["all"].items, [self.other_bg_job])
+
+        # Anonymous
+        res = self.client.get(self.url, data)
+        self.assertEqual(res.status_code, 302)
+
+    def test_search_term_with_type_and_keyword(self):
+        """Test permissions for search view limited by type and project."""
+        data = {
+            "s": (
+                "description "
+                "type:containerbackgroundjob "
+                f"project:{self.project.sodar_uuid}"
+            )
+        }
+
+        # Superuser sees everything
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(set(results["all"].items), set([self.bg_job]))
+
+        # Good users see only the container in their project
+        for user in self.good_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [self.bg_job])
+
+        # Bad users should not see any results
+        for user in self.bad_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [])
+
+        # Special users
+        results = self._get_search_results(self.user_contributor_cat, data)
+        self.assertEqual(set(results["all"].items), set([self.bg_job]))
+        results = self._get_search_results(self.user_finder_cat, data)
+        self.assertEqual(results["all"].items, [])
+
+        # Anonymous
+        res = self.client.get(self.url, data)
+        self.assertEqual(res.status_code, 302)

--- a/containers/tests/test_permissions.py
+++ b/containers/tests/test_permissions.py
@@ -628,6 +628,7 @@ class TestSearchPermissions(ProjectPermissionTestBase):
             container=self.other_container,
             user=self.user_contributor_cat,
         )
+        # Promote user to guest
         self.make_assignment(
             self.other_project, self.user_finder_cat, self.role_guest
         )

--- a/containertemplates/models.py
+++ b/containertemplates/models.py
@@ -1,11 +1,75 @@
+from typing import Optional
 import uuid
 
 from django.conf import settings
+from django.core.exceptions import ValidationError
 from django.db import models
-from django.db.models import JSONField
+from django.db.models import JSONField, Q, QuerySet
 from django.urls import reverse
 from django.utils.timezone import localtime
 from projectroles.models import Project
+
+
+class ContainerTemplateSiteManager(models.Manager):
+    """Manager for custom queries on container site templates"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container templates matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of Container objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(repository__icontains=t), Q.OR)
+            term_query.add(Q(title__icontains=t), Q.OR)
+            term_query.add(Q(description__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace("-", ""))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        return super().get_queryset().filter(term_query).order_by("title")
+
+
+class ContainerTemplateProjectManager(models.Manager):
+    """Manager for custom queries on container project templates"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container templates matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of Container objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(repository__icontains=t), Q.OR)
+            term_query.add(Q(title__icontains=t), Q.OR)
+            term_query.add(Q(description__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace("-", ""))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        if keywords and "project" in keywords:
+            try:
+                project = Project.objects.get(sodar_uuid=keywords["project"])
+                term_query.add(
+                    Q(project__full_title__startswith=project.full_title), Q.AND
+                )
+            except Project.DoesNotExist:
+                return ContainerTemplateProject.objects.none()
+            except ValidationError:
+                return ContainerTemplateProject.objects.none()
+        return super().get_queryset().filter(term_query).order_by("title")
 
 
 class ContainerTemplateBase(models.Model):
@@ -145,6 +209,9 @@ class ContainerTemplateSite(ContainerTemplateBase):
         ordering = ('-date_created',)
         unique_together = ('title',)
 
+    # Set manager for custom queries
+    objects = ContainerTemplateSiteManager()
+
     def get_absolute_url(self):
         return reverse(
             'containertemplates:site-detail',
@@ -178,6 +245,9 @@ class ContainerTemplateProject(ContainerTemplateBase):
         null=True,
         blank=True,
     )
+
+    # Set manager for custom queries
+    objects = ContainerTemplateProjectManager()
 
     class Meta:
         ordering = ('-date_created',)

--- a/containertemplates/models.py
+++ b/containertemplates/models.py
@@ -10,68 +10,6 @@ from django.utils.timezone import localtime
 from projectroles.models import Project
 
 
-class ContainerTemplateSiteManager(models.Manager):
-    """Manager for custom queries on container site templates"""
-
-    def find(
-        self, search_terms: list[str], keywords: Optional[dict] = None
-    ) -> QuerySet:
-        """
-        Return container templates matching the query.
-
-        :param search_terms: Search terms (list of strings)
-        :param keywords: Optional search keywords as key/value pairs (dict)
-        :return: QuerySet of Container objects
-        """
-        term_query = Q()
-        for t in search_terms:
-            term_query.add(Q(repository__icontains=t), Q.OR)
-            term_query.add(Q(title__icontains=t), Q.OR)
-            term_query.add(Q(description__icontains=t), Q.OR)
-            try:
-                uuid.UUID(t.replace("-", ""))
-                term_query.add(Q(sodar_uuid=t), Q.OR)
-            except ValueError:
-                pass
-        return super().get_queryset().filter(term_query).order_by("title")
-
-
-class ContainerTemplateProjectManager(models.Manager):
-    """Manager for custom queries on container project templates"""
-
-    def find(
-        self, search_terms: list[str], keywords: Optional[dict] = None
-    ) -> QuerySet:
-        """
-        Return container templates matching the query.
-
-        :param search_terms: Search terms (list of strings)
-        :param keywords: Optional search keywords as key/value pairs (dict)
-        :return: QuerySet of Container objects
-        """
-        term_query = Q()
-        for t in search_terms:
-            term_query.add(Q(repository__icontains=t), Q.OR)
-            term_query.add(Q(title__icontains=t), Q.OR)
-            term_query.add(Q(description__icontains=t), Q.OR)
-            try:
-                uuid.UUID(t.replace("-", ""))
-                term_query.add(Q(sodar_uuid=t), Q.OR)
-            except ValueError:
-                pass
-        if keywords and "project" in keywords:
-            try:
-                project = Project.objects.get(sodar_uuid=keywords["project"])
-                term_query.add(
-                    Q(project__full_title__startswith=project.full_title), Q.AND
-                )
-            except Project.DoesNotExist:
-                return ContainerTemplateProject.objects.none()
-            except ValidationError:
-                return ContainerTemplateProject.objects.none()
-        return super().get_queryset().filter(term_query).order_by("title")
-
-
 class ContainerTemplateBase(models.Model):
     """Base model for a ContainerTemplate* instances."""
 
@@ -202,6 +140,31 @@ class ContainerTemplateBase(models.Model):
         return localtime(self.date_modified).strftime('%Y-%m-%d %H:%M')
 
 
+class ContainerTemplateSiteManager(models.Manager):
+    """Manager for custom queries on container site templates"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container templates matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of Container objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(repository__icontains=t), Q.OR)
+            term_query.add(Q(title__icontains=t), Q.OR)
+            term_query.add(Q(description__icontains=t), Q.OR)
+            try:
+                term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
+            except ValueError:
+                pass
+        return super().get_queryset().filter(term_query).order_by("title")
+
+
 class ContainerTemplateSite(ContainerTemplateBase):
     """Model for a ContainerTemplate instance."""
 
@@ -223,6 +186,42 @@ class ContainerTemplateSite(ContainerTemplateBase):
 
     def __repr__(self):
         return f'ContainerTemplateSite({self.title}, {self.get_repos_full()})'
+
+
+class ContainerTemplateProjectManager(models.Manager):
+    """Manager for custom queries on container project templates"""
+
+    def find(
+        self, search_terms: list[str], keywords: Optional[dict] = None
+    ) -> QuerySet:
+        """
+        Return container templates matching the query.
+
+        :param search_terms: Search terms (list of strings)
+        :param keywords: Optional search keywords as key/value pairs (dict)
+        :return: QuerySet of Container objects
+        """
+        term_query = Q()
+        for t in search_terms:
+            term_query.add(Q(repository__icontains=t), Q.OR)
+            term_query.add(Q(title__icontains=t), Q.OR)
+            term_query.add(Q(description__icontains=t), Q.OR)
+            try:
+                uuid.UUID(t.replace("-", ""))
+                term_query.add(Q(sodar_uuid=t), Q.OR)
+            except ValueError:
+                pass
+        if keywords and "project" in keywords:
+            try:
+                project = Project.objects.get(sodar_uuid=keywords["project"])
+                term_query.add(
+                    Q(project__full_title__startswith=project.full_title), Q.AND
+                )
+            except Project.DoesNotExist:
+                return ContainerTemplateProject.objects.none()
+            except ValidationError:
+                return ContainerTemplateProject.objects.none()
+        return super().get_queryset().filter(term_query).order_by("title")
 
 
 class ContainerTemplateProject(ContainerTemplateBase):

--- a/containertemplates/models.py
+++ b/containertemplates/models.py
@@ -162,7 +162,7 @@ class ContainerTemplateSiteManager(models.Manager):
                 term_query.add(Q(sodar_uuid=uuid.UUID(t)), Q.OR)
             except ValueError:
                 pass
-        return super().get_queryset().filter(term_query).order_by("title")
+        return super().get_queryset().filter(term_query).order_by('title')
 
 
 class ContainerTemplateSite(ContainerTemplateBase):
@@ -207,13 +207,13 @@ class ContainerTemplateProjectManager(models.Manager):
             term_query.add(Q(title__icontains=t), Q.OR)
             term_query.add(Q(description__icontains=t), Q.OR)
             try:
-                uuid.UUID(t.replace("-", ""))
+                uuid.UUID(t.replace('-', ''))
                 term_query.add(Q(sodar_uuid=t), Q.OR)
             except ValueError:
                 pass
-        if keywords and "project" in keywords:
+        if keywords and 'project' in keywords:
             try:
-                project = Project.objects.get(sodar_uuid=keywords["project"])
+                project = Project.objects.get(sodar_uuid=keywords['project'])
                 term_query.add(
                     Q(project__full_title__startswith=project.full_title), Q.AND
                 )
@@ -221,7 +221,7 @@ class ContainerTemplateProjectManager(models.Manager):
                 return ContainerTemplateProject.objects.none()
             except ValidationError:
                 return ContainerTemplateProject.objects.none()
-        return super().get_queryset().filter(term_query).order_by("title")
+        return super().get_queryset().filter(term_query).order_by('title')
 
 
 class ContainerTemplateProject(ContainerTemplateBase):

--- a/containertemplates/plugins.py
+++ b/containertemplates/plugins.py
@@ -77,10 +77,10 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
     app_permission = 'containertemplates.project_view'
 
     #: Enable or disable general search from project title bar
-    search_enable = True
+    search_enable = False
 
     #: List of search object types for the app
-    search_types = ['source', 'sample', 'file']
+    search_types = []
 
     #: Search results template
     search_template = 'containertemplates/_search_results.html'

--- a/containertemplates/plugins.py
+++ b/containertemplates/plugins.py
@@ -76,7 +76,9 @@ class ProjectAppPlugin(ProjectAppPluginPoint):
     #: Required permission for accessing the app
     app_permission = 'containertemplates.project_view'
 
-    #: Enable or disable general search from project title bar
+    #: Enable or disable general search from project title bar.
+    #: NOTE: searching for container templates is implemented in the containers
+    #: app plugin.
     search_enable = False
 
     #: List of search object types for the app

--- a/containertemplates/tests/test_permissions.py
+++ b/containertemplates/tests/test_permissions.py
@@ -10,7 +10,7 @@ from containertemplates.tests.factories import (
 )
 
 
-PROJECT_TYPE_PROJECT = SODAR_CONSTANTS["PROJECT_TYPE_PROJECT"]
+PROJECT_TYPE_PROJECT = SODAR_CONSTANTS['PROJECT_TYPE_PROJECT']
 
 
 class TestContainerTemplateSitePermissions(ProjectPermissionTestBase):
@@ -383,34 +383,6 @@ class TestContainerTemplateProjectPermissionsReadOnly(
         )
         good_users = [
             self.superuser,
-        self.assert_response(url, good_users, 200, method="POST", data=data)
-        self.assert_response(url, bad_users, 302, method="POST", data=data)
-
-
-class TestSearchPermissions(ProjectPermissionTestBase):
-    """Test permissions for searching."""
-
-    def setUp(self):
-        super().setUp()
-        self.other_project = self.make_project(
-            "other_project",
-            PROJECT_TYPE_PROJECT,
-            self.category,
-            description="description",
-        )
-        self.template_site = ContainerTemplateSiteFactory()
-        self.template_project = ContainerTemplateProjectFactory(
-            project=self.project
-        )
-        self.other_template_project = ContainerTemplateProjectFactory(
-            project=self.other_project
-        )
-        # Promote user to guest
-        self.make_assignment(
-            self.other_project, self.user_finder_cat, self.role_guest
-        )
-        self.url = reverse("projectroles:search")
-        self.good_users = [
             self.user_owner,
             self.user_delegate,
             self.user_contributor,
@@ -529,6 +501,37 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         bad_users = [self.anonymous]
         self.assert_response(url, good_users, 200, method='POST', data=data)
         self.assert_response(url, bad_users, 302, method='POST', data=data)
+
+
+class TestSearchPermissions(ProjectPermissionTestBase):
+    """Test permissions for searching."""
+
+    def setUp(self):
+        super().setUp()
+        self.other_project = self.make_project(
+            'other_project',
+            PROJECT_TYPE_PROJECT,
+            self.category,
+            description='description',
+        )
+        self.template_site = ContainerTemplateSiteFactory()
+        self.template_project = ContainerTemplateProjectFactory(
+            project=self.project
+        )
+        self.other_template_project = ContainerTemplateProjectFactory(
+            project=self.other_project
+        )
+        # Promote user to guest
+        self.make_assignment(
+            self.other_project, self.user_finder_cat, self.role_guest
+        )
+        self.url = reverse('projectroles:search')
+        self.good_users = [
+            self.user_owner,
+            self.user_delegate,
+            self.user_contributor,
+            self.user_guest,
+        ]
         self.bad_users = [self.user_viewer, self.user_no_roles]
 
     def _get_search_results(self, user, data):
@@ -536,19 +539,19 @@ class TestSearchPermissions(ProjectPermissionTestBase):
             res = self.client.get(self.url, data)
             context = res.context
         self.assertEqual(res.status_code, 200)
-        self.assertEqual(context["search_input"], data["s"])
-        for app in context["app_results"]:
-            if app["plugin"].name == "containers":
-                return app["results"]
+        self.assertEqual(context['search_input'], data['s'])
+        for app in context['app_results']:
+            if app['plugin'].name == 'containers':
+                return app['results']
 
     def test_search_term(self):
         """Test permissions for search view."""
-        data = {"s": "description"}
+        data = {'s': 'description'}
 
         # Superuser sees everything
         results = self._get_search_results(self.superuser, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set(
                 [
                     self.template_site,
@@ -562,19 +565,19 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         for user in self.good_users:
             results = self._get_search_results(user, data)
             self.assertEqual(
-                set(results["all"].items),
+                set(results['all'].items),
                 set([self.template_project, self.template_site]),
             )
 
         # Bad users should only see the site template
         for user in self.bad_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [self.template_site])
+            self.assertEqual(results['all'].items, [self.template_site])
 
         # Special users
         results = self._get_search_results(self.user_contributor_cat, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set(
                 [
                     self.template_project,
@@ -585,7 +588,7 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         )
         results = self._get_search_results(self.user_finder_cat, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set([self.other_template_project, self.template_site]),
         )
 
@@ -596,17 +599,17 @@ class TestSearchPermissions(ProjectPermissionTestBase):
     def test_search_term_with_type_and_keyword(self):
         """Test permissions for search view limited by type and project."""
         data = {
-            "s": (
-                "repository "
-                "type:containertemplate "
-                f"project:{self.project.sodar_uuid}"
+            's': (
+                'repository '
+                'type:containertemplate '
+                f'project:{self.project.sodar_uuid}'
             )
         }
 
         # Superuser sees everything
         results = self._get_search_results(self.superuser, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set([self.template_project, self.template_site]),
         )
 
@@ -614,23 +617,23 @@ class TestSearchPermissions(ProjectPermissionTestBase):
         for user in self.good_users:
             results = self._get_search_results(user, data)
             self.assertEqual(
-                set(results["all"].items),
+                set(results['all'].items),
                 set([self.template_project, self.template_site]),
             )
 
         # Bad users should only see the site template
         for user in self.bad_users:
             results = self._get_search_results(user, data)
-            self.assertEqual(results["all"].items, [self.template_site])
+            self.assertEqual(results['all'].items, [self.template_site])
 
         # Special users
         results = self._get_search_results(self.user_contributor_cat, data)
         self.assertEqual(
-            set(results["all"].items),
+            set(results['all'].items),
             set([self.template_project, self.template_site]),
         )
         results = self._get_search_results(self.user_finder_cat, data)
-        self.assertEqual(results["all"].items, [self.template_site])
+        self.assertEqual(results['all'].items, [self.template_site])
 
         # Anonymous
         res = self.client.get(self.url, data)
@@ -638,6 +641,6 @@ class TestSearchPermissions(ProjectPermissionTestBase):
 
     def test_search_empty(self):
         """Test permissions for search view with empty results."""
-        data = {"s": "repository type:containerlogentry"}
+        data = {'s': 'repository type:containerlogentry'}
         results = self._get_search_results(self.superuser, data)
-        self.assertEqual(results["all"].items, [])
+        self.assertEqual(results['all'].items, [])

--- a/containertemplates/tests/test_permissions.py
+++ b/containertemplates/tests/test_permissions.py
@@ -1,12 +1,16 @@
 """Permission tests."""
 
 from django.urls import reverse
+from projectroles.models import SODAR_CONSTANTS
 from projectroles.tests.base import ProjectPermissionTestBase
 
 from containertemplates.tests.factories import (
     ContainerTemplateSiteFactory,
     ContainerTemplateProjectFactory,
 )
+
+
+PROJECT_TYPE_PROJECT = SODAR_CONSTANTS["PROJECT_TYPE_PROJECT"]
 
 
 class TestContainerTemplateSitePermissions(ProjectPermissionTestBase):
@@ -379,6 +383,34 @@ class TestContainerTemplateProjectPermissionsReadOnly(
         )
         good_users = [
             self.superuser,
+        self.assert_response(url, good_users, 200, method="POST", data=data)
+        self.assert_response(url, bad_users, 302, method="POST", data=data)
+
+
+class TestSearchPermissions(ProjectPermissionTestBase):
+    """Test permissions for searching."""
+
+    def setUp(self):
+        super().setUp()
+        self.other_project = self.make_project(
+            "other_project",
+            PROJECT_TYPE_PROJECT,
+            self.category,
+            description="description",
+        )
+        self.template_site = ContainerTemplateSiteFactory()
+        self.template_project = ContainerTemplateProjectFactory(
+            project=self.project
+        )
+        self.other_template_project = ContainerTemplateProjectFactory(
+            project=self.other_project
+        )
+        # Promote user to guest
+        self.make_assignment(
+            self.other_project, self.user_finder_cat, self.role_guest
+        )
+        self.url = reverse("projectroles:search")
+        self.good_users = [
             self.user_owner,
             self.user_delegate,
             self.user_contributor,
@@ -497,3 +529,115 @@ class TestContainerTemplateProjectPermissionsReadOnly(
         bad_users = [self.anonymous]
         self.assert_response(url, good_users, 200, method='POST', data=data)
         self.assert_response(url, bad_users, 302, method='POST', data=data)
+        self.bad_users = [self.user_viewer, self.user_no_roles]
+
+    def _get_search_results(self, user, data):
+        with self.login(user):
+            res = self.client.get(self.url, data)
+            context = res.context
+        self.assertEqual(res.status_code, 200)
+        self.assertEqual(context["search_input"], data["s"])
+        for app in context["app_results"]:
+            if app["plugin"].name == "containers":
+                return app["results"]
+
+    def test_search_term(self):
+        """Test permissions for search view."""
+        data = {"s": "description"}
+
+        # Superuser sees everything
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set(
+                [
+                    self.template_site,
+                    self.template_project,
+                    self.other_template_project,
+                ]
+            ),
+        )
+
+        # Good users see only the container templates in their project
+        for user in self.good_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(
+                set(results["all"].items),
+                set([self.template_project, self.template_site]),
+            )
+
+        # Bad users should only see the site template
+        for user in self.bad_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [self.template_site])
+
+        # Special users
+        results = self._get_search_results(self.user_contributor_cat, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set(
+                [
+                    self.template_project,
+                    self.other_template_project,
+                    self.template_site,
+                ]
+            ),
+        )
+        results = self._get_search_results(self.user_finder_cat, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set([self.other_template_project, self.template_site]),
+        )
+
+        # Anonymous
+        res = self.client.get(self.url, data)
+        self.assertEqual(res.status_code, 302)
+
+    def test_search_term_with_type_and_keyword(self):
+        """Test permissions for search view limited by type and project."""
+        data = {
+            "s": (
+                "repository "
+                "type:containertemplate "
+                f"project:{self.project.sodar_uuid}"
+            )
+        }
+
+        # Superuser sees everything
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set([self.template_project, self.template_site]),
+        )
+
+        # Good users see only the container in their project
+        for user in self.good_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(
+                set(results["all"].items),
+                set([self.template_project, self.template_site]),
+            )
+
+        # Bad users should only see the site template
+        for user in self.bad_users:
+            results = self._get_search_results(user, data)
+            self.assertEqual(results["all"].items, [self.template_site])
+
+        # Special users
+        results = self._get_search_results(self.user_contributor_cat, data)
+        self.assertEqual(
+            set(results["all"].items),
+            set([self.template_project, self.template_site]),
+        )
+        results = self._get_search_results(self.user_finder_cat, data)
+        self.assertEqual(results["all"].items, [self.template_site])
+
+        # Anonymous
+        res = self.client.get(self.url, data)
+        self.assertEqual(res.status_code, 302)
+
+    def test_search_empty(self):
+        """Test permissions for search view with empty results."""
+        data = {"s": "repository type:containerlogentry"}
+        results = self._get_search_results(self.superuser, data)
+        self.assertEqual(results["all"].items, [])

--- a/docs/source/introduction_interface.rst
+++ b/docs/source/introduction_interface.rst
@@ -12,6 +12,10 @@ system administrator about that matter if you are unsure.
 .. image:: figures/introduction/interface/login.png
   :alt: Login
 
+
+Projects List
+-------------
+
 Once logged in, you will see an overview of all the projects
 you are assigned to, alike SODAR. If you do expect to have
 access to a project you do not have access to, ask the leader or
@@ -22,6 +26,10 @@ administrator.
 
 .. image:: figures/introduction/interface/home.png
   :alt: Home
+
+
+Managing Containers and Container Templates
+-------------------------------------------
 
 To be able to access the Kiosc apps, click on a project. On the
 left-hand side you will have access to multiple apps, three
@@ -40,3 +48,42 @@ container templates that are accessible site-wide and not project-wide.
 
 .. image:: figures/introduction/interface/settings_menu.png
   :alt: Settings menu
+
+
+Searching Containers and Logs
+-----------------------------
+
+At the center of the top bar you will find the search box. You
+can use it to search objects such as containers, small files,
+site events, and log entries. Searching in KIOSC follows the same
+principles as in SODAR Core (you can read more about it `here
+<https://sodar-core.readthedocs.io/en/latest/app_projectroles_usage.html#search>`__).
+Briefly, you can enter search terms but also restrict the results to
+certain object types and limit the search to a particular project. Search is
+best explained by example, so here are a few strings that you can enter in the
+search box along with an explanation of what they do.
+
+``seapiper``
+  search all projects, files, timeline events, containers, and logs that contain
+  the string "seapiper"
+
+``seapiper type:container``
+  search all *containers* with "seapiper" in the title, description, or
+  repository
+
+``proteomics type:container``
+  search all *containers* with "proteomics" in the title, description, or
+  repository
+
+``seapiper type:containerbackgroundjob``
+  search all *container background jobs* related to "seapiper" containers
+
+``seapiper type:containerlogentry``
+  search all *container log entries* containing the string "seapiper"
+
+``error type:containerlogentry project:0f0556cf-0e9f-4923-b2b9-49e573b893f0``
+  search for errors in log entries for the project with UUID
+  ``0f0556cf-0e9f-4923-b2b9-49e573b893f0``
+
+For complex searches involving multiple terms you can press the *Advanced
+Search* button to the left of the search box.


### PR DESCRIPTION
This PR attempts to fix #153. In the spec I only considered the `containers` app and not `containertemplates`, but here I also add support for searching templates.

The container template search implementation may be a bit dubious: it is actually the `containers.plugin` which is responsible for searching them. This plugin searches for objects of type `Container`, `ContainerBackgroundJob`, `ContainerLogEntry`, `ContainerTemplateSite`, and `ContainerTemplateProject`. I made this decision because I wanted to present the templates together with the other elements, and this seemed the easiest way to achieve that.