### PR TITLE
Improve container state sync

### DIFF
--- a/containers/statemachines.py
+++ b/containers/statemachines.py
@@ -2,6 +2,7 @@ import shlex
 
 import docker
 import docker.errors
+import logging
 
 from django.conf import settings
 from django.db import transaction
@@ -30,6 +31,9 @@ from containers.models import (
     ACTION_UNPAUSE,
     ACTION_DELETE,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 # Increase the timeout for communication with Docker daemon.
@@ -363,30 +367,37 @@ class ContainerMachine(StateMachine):
         self.container.state = STATE_PULLING
         self.container.save()
 
-        for line in self.cli.pull(
-            repository=self.container.repository,
-            tag=self.container.tag,
-            stream=True,
-            decode=True,
-        ):
-            if (
-                line.get("progressDetail")
-                and line["progressDetail"].get("current")
-                and line["progressDetail"].get("total")
-            ):
-                docker_log_line = "{status} ({progressDetail[current]}/{progressDetail[total]})".format(
-                    **line
-                )
-            else:
-                docker_log_line = line["status"]
+        need_to_pull = True
+        for image in self.cli.images(self.container.repository):
+            if self.container.get_repos_full() in image["RepoTags"]:
+                need_to_pull = False
+                break
 
-            self.container.log_entries.create(
-                text=docker_log_line,
-                process=PROCESS_DOCKER,
-                date_docker_log=timezone.now(),
-                user=self.user,
-            )
-            self.job.add_log_entry(docker_log_line)
+        if need_to_pull:
+            for line in self.cli.pull(
+                repository=self.container.repository,
+                tag=self.container.tag,
+                stream=True,
+                decode=True,
+            ):
+                if (
+                    line.get("progressDetail")
+                    and line["progressDetail"].get("current")
+                    and line["progressDetail"].get("total")
+                ):
+                    docker_log_line = "{status} ({progressDetail[current]}/{progressDetail[total]})".format(
+                        **line
+                    )
+                else:
+                    docker_log_line = line["status"]
+
+                self.container.log_entries.create(
+                    text=docker_log_line,
+                    process=PROCESS_DOCKER,
+                    date_docker_log=timezone.now(),
+                    user=self.user,
+                )
+                self.job.add_log_entry(docker_log_line)
 
         image_details = self.cli.inspect_image(self.container.get_repos_full())
         self.container.image_id = image_details.get("Id")
@@ -443,7 +454,7 @@ class ContainerMachine(StateMachine):
         # Create container
         container_info = self.cli.create_container(
             detach=True,
-            image=self.container.image_id,
+            image=image_details["RepoTags"][0],
             environment=environment,
             command=(
                 shlex.split(self.container.command)
@@ -552,16 +563,18 @@ class ContainerMachine(StateMachine):
 
         # Removing container and erasing container_id
         try:
-            self.cli.remove_container(self.container.container_id)
+            self.cli.remove_container(self.container.container_id, force=True)
 
-        except docker.errors.NullResource:
+        except docker.errors.NullResource as ex:
+            logger.error("Failed to delete container: %s", ex)
             self.container.log_entries.create(
                 text="Empty container ID, don't know what to delete. Continuing.",
                 process=PROCESS_TASK,
                 user=self.user,
             )
 
-        except docker.errors.NotFound:
+        except docker.errors.NotFound as ex:
+            logger.error("Failed to delete container: %s", ex)
             self.container.log_entries.create(
                 text=f"Container with {self.container.container_id} not found, nothing to delete",
                 process=PROCESS_TASK,

--- a/containers/tasks.py
+++ b/containers/tasks.py
@@ -30,6 +30,7 @@ from containers.models import (
     ContainerActionLock,
 )
 from containers.statemachines import (
+    connect_docker,
     ContainerMachine,
     ActionSwitch,
 )
@@ -53,6 +54,30 @@ class State:
         self.state = state
 
 
+def sync_container_state(container):
+    # Update container state
+    cli = connect_docker()
+    if not container.container_id:
+        logger.error(
+            "%s: Missing container ID (state is %s)",
+            container.sodar_uuid,
+            container.state,
+        )
+        return
+    try:
+        data = cli.inspect_container(container.container_id)
+        actual_state = data.get("State", {}).get("Status")
+        if container.state != actual_state:
+            logger.warning(
+                "%s: Container state our of sync", container.sodar_uuid
+            )
+            container.date_last_status_update = timezone.now()
+            container.state = actual_state
+            container.save()
+    except docker.errors.NotFound as ex:
+        logger.error(ex)
+
+
 @app.task(bind=True)
 def container_task(_self, job_id):
     """Task to change a container state"""
@@ -61,6 +86,8 @@ def container_task(_self, job_id):
     container = job.container
     user = job.bg_job.user
     tl_event = None
+    sync_container_state(container)
+
     cm = ContainerMachine(State(container.state), job=job)
 
     if timeline:

--- a/containers/tasks.py
+++ b/containers/tasks.py
@@ -116,6 +116,7 @@ def container_task(_self, job_id):
             acs.do(job.action, job.container.state)
 
         except docker.errors.NotFound as e:
+            logger.error(e)
             job.add_log_entry(
                 f"Action failed: {job.action}", level=LOG_LEVEL_ERROR
             )
@@ -141,6 +142,7 @@ def container_task(_self, job_id):
                 job.container.save()
 
         except docker.errors.DockerException as e:
+            logger.error(e)
             # Catch Docker-specific exceptions
             job.add_log_entry(
                 f"Action failed: {job.action}", level=LOG_LEVEL_ERROR
@@ -165,6 +167,7 @@ def container_task(_self, job_id):
                 container.save(force_update=True)
 
         except statemachine.exceptions.StateMachineError as e:
+            logger.error(e)
             job.add_log_entry(
                 f"Action failed: {job.action}", level=LOG_LEVEL_ERROR
             )
@@ -175,7 +178,8 @@ def container_task(_self, job_id):
                 level=LOG_LEVEL_ERROR,
             )
 
-        except ContainerActionLock.CoolDown:
+        except ContainerActionLock.CoolDown as e:
+            logger.warning(e)
             job.add_log_entry(
                 f"Action not performed: {job.action} (cool-down)",
                 level=LOG_LEVEL_WARNING,
@@ -188,6 +192,7 @@ def container_task(_self, job_id):
             )
 
         except Exception as e:
+            logger.error(e)
             # Catch all exceptions that are not coming from Docker
             job.add_log_entry(
                 f"Action failed: {job.action}", level=LOG_LEVEL_ERROR

--- a/containers/tasks.py
+++ b/containers/tasks.py
@@ -23,6 +23,7 @@ from projectroles.app_settings import AppSettingAPI
 from containers.models import (
     ContainerBackgroundJob,
     LOG_LEVEL_ERROR,
+    STATE_INITIAL,
     STATE_FAILED,
     PROCESS_TASK,
     PROCESS_DOCKER,
@@ -57,13 +58,6 @@ class State:
 def sync_container_state(container):
     # Update container state
     cli = connect_docker()
-    if not container.container_id:
-        logger.error(
-            "%s: Missing container ID (state is %s)",
-            container.sodar_uuid,
-            container.state,
-        )
-        return
     try:
         data = cli.inspect_container(container.container_id)
         actual_state = data.get("State", {}).get("Status")
@@ -74,8 +68,27 @@ def sync_container_state(container):
             container.date_last_status_update = timezone.now()
             container.state = actual_state
             container.save()
+    except docker.errors.NullResource as ex:
+        if container.state not in (STATE_INITIAL, STATE_FAILED):
+            logger.error(
+                "%s: %s (state is %s)",
+                container.sodar_uuid,
+                ex,
+                container.state,
+            )
+            container.date_last_status_update = timezone.now()
+            container.state = STATE_FAILED
+            container.container_id = ""
+            container.save()
     except docker.errors.NotFound as ex:
+        # We mark it as failed. STATE_DELETED could also be an option,
+        # but failed is more general. Besides, the container record in the db
+        # is NOT deleted.
         logger.error(ex)
+        container.date_last_status_update = timezone.now()
+        container.state = STATE_FAILED
+        container.container_id = ""
+        container.save()
 
 
 @app.task(bind=True)

--- a/containers/tests/helpers.py
+++ b/containers/tests/helpers.py
@@ -134,7 +134,7 @@ class DockerMock:
             "status": "status",
         }
     ]
-    inspect_image = {"Id": "1"}
+    inspect_image = {"Id": "1", "RepoTags": ["repository0:latest"]}
     inspect_container_started = {"State": {"Status": STATE_RUNNING}}
     inspect_container_restarted = {"State": {"Status": STATE_RUNNING}}
     inspect_container_paused = {"State": {"Status": STATE_PAUSED}}

--- a/containers/tests/test_lifecycle.py
+++ b/containers/tests/test_lifecycle.py
@@ -1,0 +1,225 @@
+"""Test state machines."""
+
+from pathlib import Path
+
+from django.test import override_settings
+
+from containers.models import (
+    ContainerLogEntry,
+    ACTION_START,
+    ACTION_STOP,
+    ACTION_RESTART,
+    ACTION_PAUSE,
+    ACTION_UNPAUSE,
+    ACTION_DELETE,
+    STATE_EXITED,
+    STATE_RUNNING,
+    STATE_PAUSED,
+    STATE_FAILED,
+    STATE_DELETED,
+)
+from containers.statemachines import connect_docker
+from containers.tasks import container_task, sync_container_state
+from containers.tests.factories import (
+    ContainerFactory,
+    ContainerBackgroundJobFactory,
+)
+from containers.tests.helpers import TestBase
+
+
+def build_testdata_container(cli, dockerfile_name):
+    dockerfile_path = (
+        Path(__file__).parent / "testdata" / (dockerfile_name + ".Dockerfile")
+    )
+    with open(dockerfile_path, "rb") as f:
+        stream = cli.build(fileobj=f, tag=dockerfile_name + ":testing")
+    # Block until building is done
+    _ = list(stream)
+
+
+@override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=0)
+class TestContainerCrash(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.cli = connect_docker()
+        # Build the sample container image
+        build_testdata_container(self.cli, "sample-app-logging")
+        build_testdata_container(self.cli, "sample-app-instacrash")
+
+        self.container = ContainerFactory(
+            project=self.project,
+            repository="sample-app-logging",
+            tag="testing",
+            host_port=0,
+        )
+
+    def _test_container_start(self):
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_START,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Starting succeeded", logs)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        self.assertTrue(self.container.image_id.startswith("sha256:"))
+        # Test from the daemon
+        for container in self.cli.containers():
+            if container["Id"] == self.container.container_id:
+                self.assertEqual(container["State"], STATE_RUNNING)
+                break
+        else:
+            raise RuntimeError("Container is not running")
+
+    def _test_container_pause(self):
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_PAUSE,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Pausing succeeded", logs)
+        self.assertEqual(self.container.state, STATE_PAUSED)
+        # Test from the daemon
+        for container in self.cli.containers():
+            if container["Id"] == self.container.container_id:
+                self.assertEqual(container["State"], STATE_PAUSED)
+                break
+        else:
+            raise RuntimeError("Container is not paused")
+
+    def _test_container_unpause(self):
+        self.assertEqual(self.container.state, STATE_PAUSED)
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_UNPAUSE,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Unpausing succeeded", logs)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        # Test from the daemon
+        for container in self.cli.containers():
+            if container["Id"] == self.container.container_id:
+                self.assertEqual(container["State"], STATE_RUNNING)
+                break
+        else:
+            raise RuntimeError("Container is not unpaused")
+
+    def _test_container_stop(self):
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        image_id = self.container.image_id
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_STOP,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Stopping succeeded", logs)
+        self.assertEqual(self.container.state, STATE_EXITED)
+        # Test from the daemon (container should not be found)
+        for container in self.cli.containers():
+            if container["ImageID"] == image_id:
+                raise RuntimeError("Container did not stop successfully")
+
+    def _test_container_restart(self):
+        self.assertEqual(self.container.state, STATE_EXITED)
+        container_id_before = self.container.container_id
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_RESTART,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Deleting succeeded", logs)
+        container_id_after = self.container.container_id
+        self.assertNotEqual(container_id_before, container_id_after)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        # Test from the daemon
+        for container in self.cli.containers():
+            if container["Id"] == self.container.container_id:
+                self.assertEqual(container["State"], STATE_RUNNING)
+                break
+        else:
+            raise RuntimeError("Container did not restart")
+
+    def _test_container_delete(self):
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        image_id = self.container.image_id
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_DELETE,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        self.assertEqual(self.container.state, STATE_DELETED)
+        # Test from the daemon (container should not be found)
+        for container in self.cli.containers():
+            if container["ImageID"] == image_id:
+                raise RuntimeError("Container was not deleted successfully")
+
+    def test_container_lifecycle(self):
+        self._test_container_start()
+        self._test_container_pause()
+        self._test_container_unpause()
+        self._test_container_stop()
+        self._test_container_restart()
+        self._test_container_delete()
+
+    def test_container_crash_stop(self):
+        self._test_container_start()
+        self.cli.stop(self.container.container_id)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        old_container_id = self.container.container_id
+        sync_container_state(self.container)
+        self.container.refresh_from_db()
+        self.assertEqual(self.container.state, STATE_EXITED)
+        self.assertEqual(old_container_id, self.container.container_id)
+        self._test_container_delete()
+
+    def test_container_crash_delete(self):
+        self._test_container_start()
+        self.cli.remove_container(self.container.container_id, force=True)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        sync_container_state(self.container)
+        self.container.refresh_from_db()
+        self.assertEqual(self.container.state, STATE_FAILED)
+        self.assertEqual(self.container.container_id, "")
+        # No need to delete the container again
+
+    def test_container_delete_unsynced(self):
+        """Test situation where an unsynced container gets deleted"""
+        self._test_container_start()
+        self.container.state = STATE_EXITED  # But it's actually still running
+        self.container.save()
+        image_id = self.container.image_id
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_DELETE,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        # Test from the daemon (container should not be found)
+        for container in self.cli.containers():
+            if container["ImageID"] == image_id:
+                raise RuntimeError("Container was not deleted successfully")

--- a/containers/tests/test_lifecycle.py
+++ b/containers/tests/test_lifecycle.py
@@ -51,6 +51,7 @@ class TestContainerCrash(TestBase):
             repository="sample-app-logging",
             tag="testing",
             host_port=0,
+            container_id=None,
         )
 
     def _test_container_start(self):
@@ -159,8 +160,8 @@ class TestContainerCrash(TestBase):
         else:
             raise RuntimeError("Container did not restart")
 
-    def _test_container_delete(self):
-        self.assertEqual(self.container.state, STATE_RUNNING)
+    def _test_container_delete(self, initial=STATE_RUNNING):
+        self.assertEqual(self.container.state, initial)
         image_id = self.container.image_id
         bg_job = ContainerBackgroundJobFactory(
             user=self.superuser,
@@ -193,7 +194,7 @@ class TestContainerCrash(TestBase):
         self.container.refresh_from_db()
         self.assertEqual(self.container.state, STATE_EXITED)
         self.assertEqual(old_container_id, self.container.container_id)
-        self._test_container_delete()
+        self._test_container_delete(initial=STATE_EXITED)
 
     def test_container_crash_delete(self):
         self._test_container_start()
@@ -210,16 +211,4 @@ class TestContainerCrash(TestBase):
         self._test_container_start()
         self.container.state = STATE_EXITED  # But it's actually still running
         self.container.save()
-        image_id = self.container.image_id
-        bg_job = ContainerBackgroundJobFactory(
-            user=self.superuser,
-            action=ACTION_DELETE,
-            container=self.container,
-        )
-        container_task(job_id=bg_job.pk)
-        # Test from the database
-        self.container.refresh_from_db()
-        # Test from the daemon (container should not be found)
-        for container in self.cli.containers():
-            if container["ImageID"] == image_id:
-                raise RuntimeError("Container was not deleted successfully")
+        self._test_container_delete(initial=STATE_EXITED)

--- a/containers/tests/test_tasks.py
+++ b/containers/tests/test_tasks.py
@@ -109,7 +109,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image='repository0:latest',
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -201,7 +201,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image='repository0:latest',
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -304,7 +304,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image='repository0:latest',
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -408,7 +408,7 @@ class TestContainerTask(TestBase):
 
         create_container.assert_called_once_with(
             detach=True,
-            image='repository0:latest',
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -567,7 +567,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image='repository0:latest',
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -601,7 +601,9 @@ class TestContainerTask(TestBase):
         stop.assert_called_once_with(self.container1.container_id)
         pause.assert_not_called()
         unpause.assert_not_called()
-        remove_container.assert_called_once_with(self.container1.container_id, force=True)
+        remove_container.assert_called_once_with(
+            self.container1.container_id, force=True
+        )
 
     @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")

--- a/containers/tests/test_tasks.py
+++ b/containers/tests/test_tasks.py
@@ -56,6 +56,7 @@ class TestContainerTask(TestBase):
         self.cli.prune_images()
 
     @override_settings(KIOSC_NETWORK_MODE="host")
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -82,6 +83,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         create_container.side_effect = [DockerMock.create_container]
@@ -107,7 +109,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image='repository0:latest',
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -142,6 +144,7 @@ class TestContainerTask(TestBase):
         remove_container.assert_not_called()
 
     @override_settings(KIOSC_NETWORK_MODE="docker-shared")
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -168,6 +171,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         create_container.side_effect = [DockerMock.create_container]
@@ -197,7 +201,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image='repository0:latest',
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -232,6 +236,7 @@ class TestContainerTask(TestBase):
         remove_container.assert_not_called()
 
     @override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=10)
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -258,6 +263,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         bg_job2 = ContainerBackgroundJobFactory(
@@ -298,7 +304,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image='repository0:latest',
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -333,6 +339,7 @@ class TestContainerTask(TestBase):
         remove_container.assert_not_called()
 
     @override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=0)
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -359,6 +366,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         bg_job2 = ContainerBackgroundJobFactory(
@@ -400,7 +408,7 @@ class TestContainerTask(TestBase):
 
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image='repository0:latest',
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -436,6 +444,7 @@ class TestContainerTask(TestBase):
         unpause.assert_not_called()
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -462,6 +471,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.bg_job.action = ACTION_STOP
@@ -495,6 +505,7 @@ class TestContainerTask(TestBase):
         unpause.assert_not_called()
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -521,6 +532,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.bg_job.action = ACTION_RESTART
@@ -555,7 +567,7 @@ class TestContainerTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image='repository0:latest',
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -589,8 +601,9 @@ class TestContainerTask(TestBase):
         stop.assert_called_once_with(self.container1.container_id)
         pause.assert_not_called()
         unpause.assert_not_called()
-        remove_container.assert_called_once_with(self.container1.container_id)
+        remove_container.assert_called_once_with(self.container1.container_id, force=True)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -617,6 +630,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.bg_job.action = ACTION_PAUSE
@@ -648,6 +662,7 @@ class TestContainerTask(TestBase):
         unpause.assert_not_called()
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -674,6 +689,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.bg_job.action = ACTION_UNPAUSE
@@ -705,6 +721,7 @@ class TestContainerTask(TestBase):
         unpause.assert_called_once_with(self.container1.container_id)
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -731,6 +748,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         container_id = DockerMock.create_container.get("Id")
@@ -762,6 +780,7 @@ class TestContainerTask(TestBase):
         unpause.assert_not_called()
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -788,6 +807,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         container_id = DockerMock.create_container.get("Id")
@@ -818,8 +838,9 @@ class TestContainerTask(TestBase):
         stop.assert_called_once_with(container_id)
         pause.assert_not_called()
         unpause.assert_not_called()
-        remove_container.assert_called_once_with(container_id)
+        remove_container.assert_called_once_with(container_id, force=True)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -846,6 +867,7 @@ class TestContainerTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         container_id = DockerMock.create_container.get("Id")
@@ -875,7 +897,7 @@ class TestContainerTask(TestBase):
         stop.assert_not_called()
         pause.assert_not_called()
         unpause.assert_not_called()
-        remove_container.assert_called_once_with(container_id)
+        remove_container.assert_called_once_with(container_id, force=True)
 
     @tag("docker-server")
     @override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=0)

--- a/containers/tests/testdata/sample-app-instacrash.Dockerfile
+++ b/containers/tests/testdata/sample-app-instacrash.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+CMD ["INEXISTING_COMMAND", "--should-fail"]

--- a/containers/tests/testdata/sample-app-logging.Dockerfile
+++ b/containers/tests/testdata/sample-app-logging.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+CMD ["sh", "-c", "for s in `seq 1 10000`; do echo $s; sleep .2; done"]

--- a/containers/views.py
+++ b/containers/views.py
@@ -68,7 +68,7 @@ from containers.models import (
     STATE_INITIAL,
     LOG_LEVEL_ERROR,
 )
-from containers.tasks import container_task
+from containers.tasks import container_task, sync_container_state
 from containertemplates.forms import ContainerTemplateSelectorForm
 
 
@@ -369,6 +369,10 @@ class ContainerDetailView(
     model = Container
     slug_url_kwarg = "container"
     slug_field = "sodar_uuid"
+
+    def get(self, request, *args, **kwargs):
+        sync_container_state(self.get_object())
+        return super().get(request, *args, **kwargs)
 
 
 class ContainerStartView(

--- a/kioscadmin/tasks.py
+++ b/kioscadmin/tasks.py
@@ -24,6 +24,8 @@ from containers.models import (
     Container,
     ContainerBackgroundJob,
     STATE_FAILED,
+    STATE_INITIAL,
+    STATE_DELETED,
     PROCESS_TASK,
     PROCESS_DOCKER,
     LOG_LEVEL_WARNING,
@@ -129,6 +131,10 @@ def poll_docker_status_and_logs(_self):
             data = cli.inspect_container(container.container_id)
 
         except docker.errors.NotFound:
+            logger.error(
+                "%s: Container not found when polling status and logs.",
+                container.sodar_uuid,
+            )
             container.container_id = ""
             container.state = STATE_FAILED
             container.save()
@@ -194,6 +200,16 @@ def sync_container_state_with_last_user_action(_self):
 
     for container in Container.objects.all():
         if not container.container_id:
+            if container.state not in (
+                STATE_INITIAL,
+                STATE_DELETED,
+                STATE_FAILED,
+            ):
+                logger.error(
+                    "%s: Unexpected container state (%s) in kioscadmin task.",
+                    container.sodar_uuid,
+                    container.state,
+                )
             continue
 
         try:
@@ -211,6 +227,11 @@ def sync_container_state_with_last_user_action(_self):
 
             # Do nothing, Docker state needs to be synced first
             if not container.state == state:
+                logger.warning(
+                    "%s: Container state out of sync. "
+                    "Skipping job action synchronization.",
+                    container.sodar_uuid,
+                )
                 continue
 
             # Reset counter when action and state are in harmony
@@ -218,6 +239,13 @@ def sync_container_state_with_last_user_action(_self):
                 job.retries = 0
                 job.save()
                 continue
+
+            logger.warning(
+                "%s: Container state (%s) out of sync with job action (%s)",
+                container.sodar_uuid,
+                state,
+                job.action,
+            )
 
             if (
                 container.date_last_status_update
@@ -236,6 +264,29 @@ def sync_container_state_with_last_user_action(_self):
                 job.save()
 
 
+@app.task(bind=True)
+def prune_zombie_containers(_self):
+    if settings.KIOSC_NETWORK_MODE != "docker-shared":
+        # Only run in docker-shared mode: we don't want to kill containers which
+        # are not our own.
+        return
+
+    cli = connect_docker()
+    for container in cli.containers():
+        if (
+            settings.KIOSC_DOCKER_NETWORK
+            not in container["NetworkSettings"]["Networks"]
+        ):
+            # Leave this container alone, it doesn't belong to KIOSC
+            continue
+
+        try:
+            container = Container.objects.get(container_id=container["Id"])
+        except Container.DoesNotExist:
+            logger.warning("Found zombie container: %s", container["Id"])
+            cli.remove_container(container["Id"], force=True)
+
+
 @app.on_after_finalize.connect
 def setup_periodic_tasks(sender, **_kwargs):
     """Register periodic tasks"""
@@ -245,4 +296,7 @@ def setup_periodic_tasks(sender, **_kwargs):
     )
     sender.add_periodic_task(
         crontab(hour=1, minute=11), sig=stop_inactive_containers.s()
+    )
+    sender.add_periodic_task(
+        crontab(hour="*", minute=30), sig=prune_zombie_containers.s()
     )

--- a/kioscadmin/tasks.py
+++ b/kioscadmin/tasks.py
@@ -11,7 +11,7 @@ from django.conf import settings
 
 from django.utils import timezone
 
-from containers.tasks import container_task
+from containers.tasks import container_task, sync_container_state
 from projectroles.models import SODAR_CONSTANTS
 
 from config.celery import app
@@ -124,74 +124,53 @@ def poll_docker_status_and_logs(_self):
     cli = connect_docker()
 
     for container in Container.objects.all():
+        sync_container_state(container)
+        container.refresh_from_db()
         if not container.container_id:
             continue
 
+        last_log = container.log_entries.filter(process=PROCESS_DOCKER).last()
+        fetch_logs_parameters = {"timestamps": True}
+        date_last_logs = None
+
+        if last_log:
+            date_last_logs = last_log.date_docker_log
+            fetch_logs_parameters["since"] = date_last_logs.replace(tzinfo=None)
+
+        # Get most recent logs. ``since`` does not consider milliseconds,
+        # so we need to post-filter to avoid duplicates.
         try:
-            data = cli.inspect_container(container.container_id)
-
-        except docker.errors.NotFound:
-            logger.error(
-                "%s: Container not found when polling status and logs.",
-                container.sodar_uuid,
+            logs = (
+                cli.logs(container.container_id, **fetch_logs_parameters)
+                .decode("utf-8")
+                .strip()
+                .split("\n")
             )
-            container.container_id = ""
-            container.state = STATE_FAILED
-            container.save()
 
-        else:
-            state = data.get("State", {}).get("Status")
-            last_log = container.log_entries.filter(
-                process=PROCESS_DOCKER
-            ).last()
-            fetch_logs_parameters = {"timestamps": True}
-            date_last_logs = None
+        except docker.errors.DockerException as e:
+            # Log somewhere?
+            raise e
 
-            if last_log:
-                date_last_logs = last_log.date_docker_log
-                fetch_logs_parameters["since"] = date_last_logs.replace(
-                    tzinfo=None
-                )
-
-            # Get most recent logs. ``since`` does not consider milliseconds,
-            # so we need to post-filter to avoid duplicates.
+        for line in logs:
             try:
-                logs = (
-                    cli.logs(container.container_id, **fetch_logs_parameters)
-                    .decode("utf-8")
-                    .strip()
-                    .split("\n")
-                )
-
-            except docker.errors.DockerException as e:
-                # Log somewhere?
-                raise e
-
-            if state and not container.state == state:
-                container.date_last_status_update = timezone.now()
-                container.state = state
-                container.save()
-
-            for line in logs:
-                try:
-                    text = line[31:]
-                    log_date = dateutil.parser.parse(line[:30])
-                except dateutil.parser.ParserError:
-                    container.log_entries.create(
-                        text=f"Docker log has no timestamp! ({line})",
-                        level=LOG_LEVEL_WARNING,
-                        process=PROCESS_TASK,
-                    )
-                    continue
-
-                # Filter out duplicates
-                if date_last_logs and log_date <= date_last_logs:
-                    continue
-
-                # Write new log entry
+                text = line[31:]
+                log_date = dateutil.parser.parse(line[:30])
+            except dateutil.parser.ParserError:
                 container.log_entries.create(
-                    date_docker_log=log_date, text=text, process=PROCESS_DOCKER
+                    text=f"Docker log has no timestamp! ({line})",
+                    level=LOG_LEVEL_WARNING,
+                    process=PROCESS_TASK,
                 )
+                continue
+
+            # Filter out duplicates
+            if date_last_logs and log_date <= date_last_logs:
+                continue
+
+            # Write new log entry
+            container.log_entries.create(
+                date_docker_log=log_date, text=text, process=PROCESS_DOCKER
+            )
 
 
 @app.task(bind=True)

--- a/kioscadmin/tests/test_tasks.py
+++ b/kioscadmin/tests/test_tasks.py
@@ -64,9 +64,12 @@ class TestPollDockerStatusAndLogsTask(TestBase):
             project=self.project, user=self.superuser, container=self.container1
         )
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.logs")
     @patch("docker.api.client.APIClient.inspect_container")
-    def test_all_new_entries(self, inspect_container, _logs):
+    def test_all_new_entries(
+        self, inspect_container, _logs, _sync_container_state
+    ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
 
         # Prepare
@@ -100,9 +103,12 @@ class TestPollDockerStatusAndLogsTask(TestBase):
             self.container1.container_id, timestamps=True
         )
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.logs")
     @patch("docker.api.client.APIClient.inspect_container")
-    def test_all_new_entries_no_date(self, inspect_container, _logs):
+    def test_all_new_entries_no_date(
+        self, inspect_container, _logs, _sync_container_state
+    ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
 
         # Prepare
@@ -136,9 +142,12 @@ class TestPollDockerStatusAndLogsTask(TestBase):
             self.container1.container_id, timestamps=True
         )
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.logs")
     @patch("docker.api.client.APIClient.inspect_container")
-    def test_add_entries_since_date(self, inspect_container, _logs):
+    def test_add_entries_since_date(
+        self, inspect_container, _logs, _sync_container_state
+    ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
 
         # Prepare

--- a/kioscadmin/tests/test_tasks.py
+++ b/kioscadmin/tests/test_tasks.py
@@ -7,6 +7,7 @@ from unittest.mock import patch, call
 import docker.errors
 from django.conf import settings
 from django.utils import timezone
+from django.test import override_settings
 
 from containers.models import (
     ACTION_STOP,
@@ -29,8 +30,12 @@ from kioscadmin.tasks import (
     sync_container_state_with_last_user_action,
     DEFAULT_GRACE_PERIOD_CONTAINER_STATUS,
     stop_inactive_containers,
+    prune_zombie_containers,
 )
+from containers.tasks import container_task
+from containers.tests.test_lifecycle import build_testdata_container
 from containers.tests.factories import (
+    ContainerFactory,
     ContainerBackgroundJobFactory,
     ContainerLogEntryFactory,
 )
@@ -1266,3 +1271,54 @@ class TestStopInactiveContainers(TestBase):
 
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 1)
+
+
+@override_settings(
+    KIOSC_NETWORK_MODE="docker-shared",
+    KIOSC_DOCKER_NETWORK="kiosc-docker-network-testing",
+)
+class TestPruneZombieContainers(TestBase):
+    """Tests for ``prune_zombie_containers`` task."""
+
+    def setUp(self):
+        super().setUp()
+        self.cli = connect_docker()
+        # Build the sample container image
+        build_testdata_container(self.cli, "sample-app-logging")
+        # Create the network
+        self.cli.create_network(
+            settings.KIOSC_DOCKER_NETWORK, driver="bridge", check_duplicate=True
+        )
+
+        self.container = ContainerFactory(
+            project=self.project,
+            repository="sample-app-logging",
+            tag="testing",
+            host_port=0,
+        )
+
+    def tearDown(self):
+        network = self.cli.networks(settings.KIOSC_DOCKER_NETWORK)[0]
+        self.cli.remove_network(network["Id"])
+
+    def test_prune_zombie_containers(self):
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_START,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Starting succeeded", logs)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        image_id = self.container.image_id
+        # Artificially cut the tie between kiosc and the container
+        self.container.container_id = None
+        self.container.save()
+        # Test that pruning the zombies does the job
+        prune_zombie_containers()
+        for container in self.cli.containers():
+            if container["ImageID"] == image_id:
+                # Container should not be found
+                raise RuntimeError("Container did not stop successfully")

--- a/kioscadmin/tests/test_tasks.py
+++ b/kioscadmin/tests/test_tasks.py
@@ -33,6 +33,7 @@ from kioscadmin.tasks import (
     prune_zombie_containers,
 )
 from containers.tasks import container_task
+
 from containers.tests.test_lifecycle import build_testdata_container
 from containers.tests.factories import (
     ContainerFactory,
@@ -204,6 +205,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
             project=self.project, user=self.superuser, container=self.container1
         )
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -226,6 +228,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
         inspect_container.side_effect = [DockerMock.inspect_container_started]
@@ -249,6 +252,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -271,6 +275,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.bg_job.delete()
@@ -293,6 +298,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         unpause.assert_not_called()
         remove_container.assert_not_called()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -315,6 +321,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -340,6 +347,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -362,6 +370,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -390,6 +399,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -412,6 +422,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -440,6 +451,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -462,6 +474,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -490,6 +503,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -512,6 +526,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -540,6 +555,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -562,6 +578,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -590,6 +607,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -612,6 +630,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now()
@@ -640,6 +659,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -662,6 +682,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now() - timedelta(
@@ -693,6 +714,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.bg_job.refresh_from_db()
         self.assertEqual(self.bg_job.retries, self.container1.max_retries)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -715,6 +737,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now() - timedelta(
@@ -752,6 +775,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.assertEqual(self.bg_job.retries, 1)
         self.assertEqual(self.container1.state, STATE_EXITED)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -778,6 +802,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now() - timedelta(
@@ -809,7 +834,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         # Assert mocks
         create_container.assert_called_once_with(
             detach=True,
-            image=self.container1.image_id,
+            image="repository0:latest",
             environment=environment,
             command=self.container1.command or None,
             ports=[self.container1.container_port],
@@ -843,7 +868,9 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         stop.assert_not_called()
         pause.assert_not_called()
         unpause.assert_not_called()
-        remove_container.assert_called_once_with(self.container1.container_id)
+        remove_container.assert_called_once_with(
+            self.container1.container_id, force=True
+        )
 
         # Assert objects
         self.container1.refresh_from_db()
@@ -851,6 +878,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.assertEqual(self.bg_job.retries, 1)
         self.assertEqual(self.container1.state, STATE_RUNNING)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -873,6 +901,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now() - timedelta(
@@ -910,6 +939,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         self.assertEqual(self.bg_job.retries, 1)
         self.assertEqual(self.container1.state, STATE_PAUSED)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -932,6 +962,7 @@ class TestSyncContainerStateWithLastUserActionTask(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.date_last_status_update = timezone.now() - timedelta(
@@ -981,6 +1012,7 @@ class TestStopInactiveContainers(TestBase):
         self.container1.image_id = DockerMock.inspect_image.get("Id")
         self.container1.save()
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1003,6 +1035,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
         inspect_container.side_effect = docker.errors.NotFound("x")
@@ -1025,6 +1058,7 @@ class TestStopInactiveContainers(TestBase):
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1047,6 +1081,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         self.assertEqual(self.container1.state, STATE_INITIAL)
         inspect_container.side_effect = [DockerMock.inspect_container_no_info]
@@ -1069,6 +1104,7 @@ class TestStopInactiveContainers(TestBase):
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1091,6 +1127,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         self.container1.state = STATE_EXITED
         self.container1.save()
@@ -1115,6 +1152,7 @@ class TestStopInactiveContainers(TestBase):
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1137,6 +1175,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         inspect_container.side_effect = [DockerMock.inspect_container_started]
@@ -1159,6 +1198,7 @@ class TestStopInactiveContainers(TestBase):
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1181,6 +1221,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         self.container1.log_entries.create(
@@ -1208,6 +1249,7 @@ class TestStopInactiveContainers(TestBase):
         # Assert objects
         self.assertEqual(ContainerBackgroundJob.objects.count(), 0)
 
+    @patch("containers.tasks.sync_container_state")
     @patch("docker.api.client.APIClient.remove_container")
     @patch("docker.api.client.APIClient.unpause")
     @patch("docker.api.client.APIClient.pause")
@@ -1230,6 +1272,7 @@ class TestStopInactiveContainers(TestBase):
         pause,
         unpause,
         remove_container,
+        sync_container_state,
     ):
         # Prepare
         mock_now = timezone.now() - timedelta(days=2)


### PR DESCRIPTION
This PR attempts to improve the synchronization between docker daemon and KIOSC (see #186, #197). Normally, there is a celery task that takes care of this every 30 seconds. With this PR, we enforce an additional check just before showing the container view to the user or running any action on the container.

Furthermore, we make KIOSC more robust to unsychronized state when restarting or deleting a container. This is achieved by adding the `force=True` argument to `remove_container()`, which should remove the container even if it's still running (while KIOSC thinks it's not). At the present time it is not clear whether or how this could happen in real life, but I replicated this scenario and found that, without this fix, it would result in zombie containers.

If any zombie containers should still occur, we now have a periodic background task that prunes them automatically.

Last but not least, we add a check for existing local docker images before pulling them from a repository, so that images are pulled only when necessary.