### PR TITLE
Add more tests with real docker containers

### DIFF
--- a/containers/tasks.py
+++ b/containers/tasks.py
@@ -150,7 +150,6 @@ def container_task(_self, job_id):
             with transaction.atomic():
                 job.container.refresh_from_db()
                 job.container.container_id = ""
-                job.container.image_id = ""
                 job.container.state = STATE_FAILED
                 job.container.save()
 

--- a/containers/tests/test_lifecycle.py
+++ b/containers/tests/test_lifecycle.py
@@ -253,7 +253,7 @@ class TestContainerCrash(TestBase):
         self.assertIsNone(self.container.container_id)
         # Test from the daemon
         for container in self.cli.containers(all=True):
-            if container["Image"] == 'sample-app-instacrash:testing':
+            if container["Image"] == "sample-app-instacrash:testing":
                 self.assertEqual(container["State"], STATE_CREATED)
                 break
         else:

--- a/containers/tests/test_lifecycle.py
+++ b/containers/tests/test_lifecycle.py
@@ -12,6 +12,7 @@ from containers.models import (
     ACTION_PAUSE,
     ACTION_UNPAUSE,
     ACTION_DELETE,
+    STATE_CREATED,
     STATE_EXITED,
     STATE_RUNNING,
     STATE_PAUSED,
@@ -38,13 +39,12 @@ def build_testdata_container(cli, dockerfile_name):
 
 
 @override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=0)
-class TestContainerCrash(TestBase):
+class TestContainerLifecycle(TestBase):
     def setUp(self):
         super().setUp()
         self.cli = connect_docker()
         # Build the sample container image
         build_testdata_container(self.cli, "sample-app-logging")
-        build_testdata_container(self.cli, "sample-app-instacrash")
 
         self.container = ContainerFactory(
             project=self.project,
@@ -173,11 +173,12 @@ class TestContainerCrash(TestBase):
         self.container.refresh_from_db()
         self.assertEqual(self.container.state, STATE_DELETED)
         # Test from the daemon (container should not be found)
-        for container in self.cli.containers():
+        for container in self.cli.containers(all=True):
             if container["ImageID"] == image_id:
                 raise RuntimeError("Container was not deleted successfully")
 
     def test_container_lifecycle(self):
+        """Test a typical container lifecycle"""
         self._test_container_start()
         self._test_container_pause()
         self._test_container_unpause()
@@ -186,6 +187,7 @@ class TestContainerCrash(TestBase):
         self._test_container_delete()
 
     def test_container_crash_stop(self):
+        """Simulate a container crash"""
         self._test_container_start()
         self.cli.stop(self.container.container_id)
         self.assertEqual(self.container.state, STATE_RUNNING)
@@ -197,6 +199,7 @@ class TestContainerCrash(TestBase):
         self._test_container_delete(initial=STATE_EXITED)
 
     def test_container_crash_delete(self):
+        """Simulate a container deletion"""
         self._test_container_start()
         self.cli.remove_container(self.container.container_id, force=True)
         self.assertEqual(self.container.state, STATE_RUNNING)
@@ -208,7 +211,50 @@ class TestContainerCrash(TestBase):
 
     def test_container_delete_unsynced(self):
         """Test situation where an unsynced container gets deleted"""
+        # NOTE: This test failed before #200
         self._test_container_start()
         self.container.state = STATE_EXITED  # But it's actually still running
         self.container.save()
         self._test_container_delete(initial=STATE_EXITED)
+
+
+@override_settings(KIOSC_DOCKER_ACTION_MIN_DELAY=0)
+class TestContainerCrash(TestBase):
+    def setUp(self):
+        super().setUp()
+        self.cli = connect_docker()
+        # Build the sample container image
+        build_testdata_container(self.cli, "sample-app-instacrash")
+
+        self.container = ContainerFactory(
+            project=self.project,
+            repository="sample-app-instacrash",
+            tag="testing",
+            host_port=0,
+            container_id=None,
+        )
+
+    def test_start_and_crash(self):
+        """Test starting a container that crashes"""
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_START,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        # Test from the database
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        sync_container_state(self.container)
+        self.assertNotIn("Starting succeeded", logs)
+        self.assertIn("Action failed: start", logs)
+        self.assertEqual(self.container.state, STATE_FAILED)
+        # self.assertTrue(self.container.image_id.startswith("sha256:"))
+        self.assertIsNone(self.container.container_id)
+        # Test from the daemon
+        for container in self.cli.containers(all=True):
+            if container["Image"] == 'sample-app-instacrash:testing':
+                self.assertEqual(container["State"], STATE_CREATED)
+                break
+        else:
+            raise RuntimeError("Container was not found")

--- a/containers/tests/testdata/sample-app-delaycrash.Dockerfile
+++ b/containers/tests/testdata/sample-app-delaycrash.Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:latest
+
+CMD ["/bin/sh", "-c", "sleep 10 && INEXISTING_COMMAND --should-fail"]

--- a/containers/tests/testdata/sample-app-delayserver.Dockerfile
+++ b/containers/tests/testdata/sample-app-delayserver.Dockerfile
@@ -1,0 +1,5 @@
+FROM nginx:latest
+
+RUN echo "<h1>Hello World</h1>" > /usr/share/nginx/html/index.html
+
+ENTRYPOINT ["/bin/sh", "-c", "sleep 10 && /docker-entrypoint.sh nginx -g 'daemon off;'"]

--- a/containers/tests/testdata/sample-app-instacrash.Dockerfile
+++ b/containers/tests/testdata/sample-app-instacrash.Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:latest
 
-CMD ["INEXISTING_COMMAND", "--should-fail"]
+CMD ["MYSTICAL_COMMAND", "--should-fail"]

--- a/kioscadmin/tasks.py
+++ b/kioscadmin/tasks.py
@@ -251,7 +251,7 @@ def prune_zombie_containers(_self):
         return
 
     cli = connect_docker()
-    for container in cli.containers():
+    for container in cli.containers(all=True):
         if (
             settings.KIOSC_DOCKER_NETWORK
             not in container["NetworkSettings"]["Networks"]

--- a/kioscadmin/tests/test_tasks.py
+++ b/kioscadmin/tests/test_tasks.py
@@ -1328,6 +1328,7 @@ class TestStopInactiveContainers(TestBase):
 @override_settings(
     KIOSC_NETWORK_MODE="docker-shared",
     KIOSC_DOCKER_NETWORK="kiosc-docker-network-testing",
+    KIOSC_DOCKER_ACTION_MIN_DELAY=0,
 )
 class TestPruneZombieContainers(TestBase):
     """Tests for ``prune_zombie_containers`` task."""
@@ -1347,6 +1348,7 @@ class TestPruneZombieContainers(TestBase):
             repository="sample-app-logging",
             tag="testing",
             host_port=0,
+            container_id=None,
         )
 
     def tearDown(self):
@@ -1354,6 +1356,7 @@ class TestPruneZombieContainers(TestBase):
         self.cli.remove_network(network["Id"])
 
     def test_prune_zombie_containers(self):
+        """Test that zombie containers are removed"""
         bg_job = ContainerBackgroundJobFactory(
             user=self.superuser,
             action=ACTION_START,
@@ -1370,7 +1373,42 @@ class TestPruneZombieContainers(TestBase):
         self.container.save()
         # Test that pruning the zombies does the job
         prune_zombie_containers()
-        for container in self.cli.containers():
+        for container in self.cli.containers(all=True):
+            if container["ImageID"] == image_id:
+                # Container should not be found
+                raise RuntimeError("Container did not stop successfully")
+
+    def test_prune_stopped_zombie_containers(self):
+        """Test that zombie containers are removed also if not currently running"""
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_START,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        self.container.refresh_from_db()
+        logs = [log.text for log in ContainerLogEntry.objects.all()]
+        self.assertIn("Starting succeeded", logs)
+        self.assertEqual(self.container.state, STATE_RUNNING)
+        image_id = self.container.image_id
+        container_id = self.container.container_id
+        # Stop the container
+        bg_job = ContainerBackgroundJobFactory(
+            user=self.superuser,
+            action=ACTION_STOP,
+            container=self.container,
+        )
+        container_task(job_id=bg_job.pk)
+        poll_docker_status_and_logs()
+        self.container.refresh_from_db()
+        self.assertEqual(self.container.state, STATE_EXITED)
+        self.assertEqual(self.container.container_id, container_id)
+        # Artificially cut the tie between kiosc and the container
+        self.container.container_id = None
+        self.container.save()
+        # Test that pruning the zombies does the job
+        prune_zombie_containers()
+        for container in self.cli.containers(all=True):
             if container["ImageID"] == image_id:
                 # Container should not be found
                 raise RuntimeError("Container did not stop successfully")


### PR DESCRIPTION
This PR is a small add-on to #200. It is related to #186 and #197. It should close #197 for now, until we find either more problems or a better way to handle the zombies. It handles the pruning better by using `all=True` when listing containers, so that stopped ones are included.